### PR TITLE
Send better workflow embeds on discord

### DIFF
--- a/.github/workflows/status_embed.yml
+++ b/.github/workflows/status_embed.yml
@@ -1,0 +1,68 @@
+name: Status Embed
+
+on:
+  workflow_run:
+    workflows:
+      - Validation
+      - Tox test
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  status_embed:
+    name:  Send Status Embed to Discord
+    runs-on: ubuntu-latest
+    steps:
+      # A workflow_run event does not contain all the information
+      # we need for a PR embed. That's why we upload an artifact
+      # with that information in the Lint workflow.
+      - name: Get Pull Request Information
+        id: pr_info
+        if: github.event.workflow_run.event == 'pull_request'
+        run: |
+          curl -s -H "Authorization: token $GITHUB_TOKEN" ${{ github.event.workflow_run.artifacts_url }} > artifacts.json
+          DOWNLOAD_URL=$(cat artifacts.json | jq -r '.artifacts[] | select(.name == "pull-request-payload") | .archive_download_url')
+          [ -z "$DOWNLOAD_URL" ] && exit 1
+          wget --quiet --header="Authorization: token $GITHUB_TOKEN" -O pull_request_payload.zip $DOWNLOAD_URL || exit 2
+          unzip -p pull_request_payload.zip > pull_request_payload.json
+          [ -s pull_request_payload.json ] || exit 3
+          echo "::set-output name=pr_author_login::$(jq -r '.user.login // empty' pull_request_payload.json)"
+          echo "::set-output name=pr_number::$(jq -r '.number // empty' pull_request_payload.json)"
+          echo "::set-output name=pr_title::$(jq -r '.title // empty' pull_request_payload.json)"
+          echo "::set-output name=pr_source::$(jq -r '.head.label // empty' pull_request_payload.json)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Send an informational status embed to Discord instead of the
+      # standard embeds that Discord sends. This embed will contain
+      # more information and we can fine tune when we actually want
+      # to send an embed.
+      - name: GitHub Actions Status Embed for Discord
+        uses: SebastiaanZ/github-status-embed-for-discord@v0.3.0
+        with:
+          # Our GitHub Actions webhook
+          webhook_id: '942940470059892796'
+          webhook_token: ${{ secrets.webhook_token }}
+
+          # We need to provide the information of the workflow that
+          # triggered this workflow instead of this workflow.
+          workflow_name: ${{ github.event.workflow_run.name }}
+          run_id: ${{ github.event.workflow_run.id }}
+          run_number: ${{ github.event.workflow_run.run_number }}
+          status: ${{ github.event.workflow_run.conclusion }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+
+          # Now we can use the information extracted in the previous step:
+          pr_author_login: ${{ steps.pr_info.outputs.pr_author_login }}
+          pr_number: ${{ steps.pr_info.outputs.pr_number }}
+          pr_title: ${{ steps.pr_info.outputs.pr_title }}
+          pr_source: ${{ steps.pr_info.outputs.pr_source }}
+
+          # And some additional details
+          actor: ${{ github.actor }}
+          repository:  ${{ github.repository }}
+          ref: ${{ github.ref }}

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -62,3 +62,28 @@ jobs:
         run: python -m tox
         env:
           PIP_USER: 0  # We want tox to use it's environments, not user installs
+
+      # Steps below are here to generate and upload an artifact from
+      # this workflow so that we can have the data about author and some
+      # other things accessible from the status_embed workflow.
+
+      # Prepare the pull request payload artifact. If this fails, we
+      # fail silently using the `continue-on-error` option, since failure
+      # doesn't mean that the checks in this workflow have failed.
+      - name: Prepare Pull Request Payload artifact
+        id: prepare-artifact
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
+
+      # This only makes sense if the previous step succeeded. To
+      # get the original outcome of the previous step before the
+      # `continue-on-error` conclusion is applied, we use the
+      # `.outcome` value. This step also fails silently.
+      - name: Upload a Build Artifact
+        if: always() && steps.prepare-artifact.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: pull-request-payload
+          path: pull_request_payload.json

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -61,3 +61,28 @@ jobs:
 
       - name: Run flake8 linter
         run: flake8 .
+
+      # Steps below are here to generate and upload an artifact from
+      # this workflow so that we can have the data about author and some
+      # other things accessible from the status_embed workflow.
+
+      # Prepare the pull request payload artifact. If this fails, we
+      # fail silently using the `continue-on-error` option, since failure
+      # doesn't mean that the checks in this workflow have failed.
+      - name: Prepare Pull Request Payload artifact
+        id: prepare-artifact
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
+
+      # This only makes sense if the previous step succeeded. To
+      # get the original outcome of the previous step before the
+      # `continue-on-error` conclusion is applied, we use the
+      # `.outcome` value. This step also fails silently.
+      - name: Upload a Build Artifact
+        if: always() && steps.prepare-artifact.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: pull-request-payload
+          path: pull_request_payload.json


### PR DESCRIPTION
This adds a new status_embed workflow, which will be sending a much better-looking discord embeds to our mcstatus-hooks channel. For more info, check [SebastiaanZ's github-status-embed action](https://github.com/SebastiaanZ/github-status-embed-for-discord).