### PR TITLE
Cancel workflow if a new one is already running

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -2,6 +2,10 @@ name: Tox test
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Make sure pip caches dependencies and installs as user
   PIP_NO_CACHE_DIR: false

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,6 +2,10 @@ name: Validation
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Make sure pip caches dependencies and installs as user
   PIP_NO_CACHE_DIR: false


### PR DESCRIPTION
This is an optimization which automatically cancels older workflows which are in progress if there's a new one that's already running. This can happen if someone pushes before the first workflows even finished, in which case we don't need to finish the previous running workflows, as we only ever care about the last commit passing, not all commits.

This is useful because GitHub limits the amount of concurrent workflows which can be ran on a repo, which means we'd have to wait for the these queued up workflows to finish until new ones can start, which is pointless as we don't really care about old workflow results anyway.

This cancellation only happens when the workflow is on the same `ref` (Ref being a PR, or a branch).