### PR TITLE
Fix names of the server classes

### DIFF
--- a/mcstatus/__init__.py
+++ b/mcstatus/__init__.py
@@ -1,1 +1,1 @@
-from mcstatus.server import BedrockServer, JavaServer  # noqa: F401
+from mcstatus.server import BedrockServer, JavaServer, MinecraftBedrockServer, MinecraftServer  # noqa: F401

--- a/mcstatus/__init__.py
+++ b/mcstatus/__init__.py
@@ -1,1 +1,1 @@
-from mcstatus.server import MinecraftBedrockServer, MinecraftServer  # noqa: F401
+from mcstatus.server import BedrockServer, JavaServer  # noqa: F401

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -256,7 +256,7 @@ class BedrockServer:
         return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
 
 
-@deprecated(replacement="JavaServer", date="2022-08", methods=("__init__", ))
+@deprecated(replacement="JavaServer", date="2022-08", methods=("__init__",))
 class MinecraftServer(JavaServer):
     """This is a deprecated version of the base class for a Java Minecraft Server.
 
@@ -267,7 +267,7 @@ class MinecraftServer(JavaServer):
         super().__init__(host, port=port, timeout=timeout)
 
 
-@deprecated(replacement="BedrockServer", date="2022-08", methods=("__init__", ))
+@deprecated(replacement="BedrockServer", date="2022-08", methods=("__init__",))
 class MinecraftBedrockServer(BedrockServer):
     """This is a deprecated version of the base class for a Bedrock Minecraft Server.
 

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -256,7 +256,7 @@ class BedrockServer:
         return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
 
 
-@deprecated(replacement="JavaServer")
+@deprecated(replacement="JavaServer", date="2022-08")
 class MinecraftServer(JavaServer):
     """This is a deprecated version of the base class for a Java Minecraft Server.
 
@@ -267,7 +267,7 @@ class MinecraftServer(JavaServer):
         super().__init__(host, port=port, timeout=timeout)
 
 
-@deprecated(replacement="BedrockServer")
+@deprecated(replacement="BedrockServer", date="2022-08")
 class MinecraftBedrockServer(BedrockServer):
     """This is a deprecated version of the base class for a Bedrock Minecraft Server.
 

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -256,7 +256,7 @@ class BedrockServer:
         return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
 
 
-@deprecated(replacement="JavaServer", date="2022-08")
+@deprecated(replacement="JavaServer", date="2022-08", methods=("__init__", ))
 class MinecraftServer(JavaServer):
     """This is a deprecated version of the base class for a Java Minecraft Server.
 
@@ -267,7 +267,7 @@ class MinecraftServer(JavaServer):
         super().__init__(host, port=port, timeout=timeout)
 
 
-@deprecated(replacement="BedrockServer", date="2022-08")
+@deprecated(replacement="BedrockServer", date="2022-08", methods=("__init__", ))
 class MinecraftBedrockServer(BedrockServer):
     """This is a deprecated version of the base class for a Bedrock Minecraft Server.
 

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -262,6 +262,7 @@ class MinecraftServer(JavaServer):
 
     This class is kept purely for backwards compatibility reasons and will be removed eventually.
     """
+
     def __init__(self, host: str, port: int = 25565, timeout: float = 3):
         super().__init__(host, port=port, timeout=timeout)
 
@@ -272,5 +273,6 @@ class MinecraftBedrockServer(BedrockServer):
 
     This class is kept purely for backwards compatibility reasons and will be removed eventually.
     """
+
     def __init__(self, host: str, port: int = 19139, timeout: float = 3):
         super().__init__(host, port=port, timeout=timeout)

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Optional, TYPE_CHECKING, Tuple
 from urllib.parse import urlparse
 
@@ -16,7 +15,7 @@ from mcstatus.protocol.connection import (
     UDPSocketConnection,
 )
 from mcstatus.querier import AsyncServerQuerier, QueryResponse, ServerQuerier
-from mcstatus.utils import retry
+from mcstatus.utils import deprecated, retry
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -257,6 +256,7 @@ class BedrockServer:
         return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
 
 
+@deprecated(replacement="JavaServer")
 class MinecraftServer(JavaServer):
     """This is a deprecated version of the base class for a Java Minecraft Server.
 
@@ -264,9 +264,9 @@ class MinecraftServer(JavaServer):
     """
     def __init__(self, host: str, port: int = 25565, timeout: float = 3):
         super().__init__(host, port=port, timeout=timeout)
-        warnings.warn("'MinecraftServer' is deprecated and will be removed, use 'JavaServer' instead")
 
 
+@deprecated(replacement="BedrockServer")
 class MinecraftBedrockServer(BedrockServer):
     """This is a deprecated version of the base class for a Bedrock Minecraft Server.
 
@@ -274,4 +274,3 @@ class MinecraftBedrockServer(BedrockServer):
     """
     def __init__(self, host: str, port: int = 19139, timeout: float = 3):
         super().__init__(host, port=port, timeout=timeout)
-        warnings.warn("'MinecraftBedrockServer' is deprecated and will be removed in, use 'BedrockServer' instead")

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
-__all__ = ["MinecraftServer", "MinecraftBedrockServer"]
+__all__ = ["JavaServer", "BedrockServer"]
 
 
 def parse_address(address: str) -> Tuple[str, Optional[int]]:
@@ -40,7 +40,7 @@ def ensure_valid(host: object, port: object):
         raise ValueError(f"Port must be within the allowed range (0-2^16), got {port}")
 
 
-class MinecraftServer:
+class JavaServer:
     """Base class for a Minecraft Java Edition server.
 
     :param str host: The host/address/ip of the Minecraft server.
@@ -205,7 +205,7 @@ class MinecraftServer:
         return await querier.read_query()
 
 
-class MinecraftBedrockServer:
+class BedrockServer:
     """Base class for a Minecraft Bedrock Edition server.
 
     :param str host: The host/address/ip of the Minecraft server.
@@ -254,3 +254,4 @@ class MinecraftBedrockServer:
         :rtype: BedrockStatusResponse
         """
         return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
+

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Optional, TYPE_CHECKING, Tuple
 from urllib.parse import urlparse
 
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
-__all__ = ["JavaServer", "BedrockServer"]
+__all__ = ["JavaServer", "BedrockServer", "MinecraftServer", "MinecraftBedrockServer"]
 
 
 def parse_address(address: str) -> Tuple[str, Optional[int]]:
@@ -255,3 +256,22 @@ class BedrockServer:
         """
         return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
 
+
+class MinecraftServer(JavaServer):
+    """This is a deprecated version of the base class for a Java Minecraft Server.
+
+    This class is kept purely for backwards compatibility reasons and will be removed eventually.
+    """
+    def __init__(self, host: str, port: int = 25565, timeout: float = 3):
+        super().__init__(host, port=port, timeout=timeout)
+        warnings.warn("'MinecraftServer' is deprecated and will be removed, use 'JavaServer' instead")
+
+
+class MinecraftBedrockServer(BedrockServer):
+    """This is a deprecated version of the base class for a Bedrock Minecraft Server.
+
+    This class is kept purely for backwards compatibility reasons and will be removed eventually.
+    """
+    def __init__(self, host: str, port: int = 19139, timeout: float = 3):
+        super().__init__(host, port=port, timeout=timeout)
+        warnings.warn("'MinecraftBedrockServer' is deprecated and will be removed in, use 'BedrockServer' instead")

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import warnings
 from functools import wraps
-from typing import Callable, Iterable, Tuple, Type
+from typing import Callable, Iterable, Optional, Tuple, Type
 
 
 def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> Callable:
@@ -52,11 +52,11 @@ def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> 
 
 def deprecated(
     *,
-    replacement: str = None,
-    version: str = None,
-    date: str = None,
-    msg: str = None,
-    methods: Iterable[str] = None,
+    replacement: Optional[str] = None,
+    version: Optional[str] = None,
+    date: Optional[str] = None,
+    msg: Optional[str] = None,
+    methods: Optional[Iterable[str]] = None,
 ):
     if date is not None and version is not None:
         raise ValueError("Expected removal timeframe can either be a date, or a version, not both.")

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import warnings
 from functools import wraps
-from typing import Callable, Tuple, Type, Iterable
+from typing import Callable, Iterable, Tuple, Type
 
 
 def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> Callable:

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -50,10 +50,10 @@ def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> 
 
 
 def deprecated(replacement: str = None, version: str = None, date: str = None, msg: str = None):
-    def decorate(func: Callable) -> Callable:
-        if date is not None and version is not None:
-            raise ValueError("Expected removal timeframe can either be a date, or a version, not both.")
+    if date is not None and version is not None:
+        raise ValueError("Expected removal timeframe can either be a date, or a version, not both.")
 
+    def decorate(func: Callable) -> Callable:
         # Construct and send the warning message
         name = getattr(func, "__qualname__", func.__name__)
         warn_message = f"'{name}' is deprecated and is expected to be removed"

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -63,18 +63,11 @@ def deprecated(
 
     def decorate_func(func: Callable, warn_message: str):
         @wraps(func)
-        def sync_wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs):
             warnings.warn(warn_message, category=DeprecationWarning)
             return func(*args, **kwargs)
 
-        @wraps(func)
-        async def async_wrapper(*args, **kwargs):
-            warnings.warn(warn_message, category=DeprecationWarning)
-            return await func(*args, **kwargs)
-
-        if asyncio.iscoroutinefunction(func):
-            return async_wrapper
-        return sync_wrapper
+        return wrapper
 
     def decorate(obj: Callable) -> Callable:
         # Construct and send the warning message

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -51,6 +51,7 @@ def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> 
 
 
 def deprecated(
+    obj: Optional[Callable] = None,
     *,
     replacement: Optional[str] = None,
     version: Optional[str] = None,
@@ -99,4 +100,9 @@ def deprecated(
             raise ValueError("Methods can only be specified when decorating a class, not a function")
         return decorate_func(obj, warn_message)
 
+    # In case the decorator was used like @deprecated, instead of @deprecated()
+    # we got the object already, pass it over to the local decorate function
+    # This can happen since all of the arguments are optional and can be omitted
+    if obj:
+        return decorate(obj)
     return decorate

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -56,7 +56,7 @@ def deprecated(
     version: str = None,
     date: str = None,
     msg: str = None,
-    methods: Iterable[str] = None
+    methods: Iterable[str] = None,
 ):
     if date is not None and version is not None:
         raise ValueError("Expected removal timeframe can either be a date, or a version, not both.")

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -49,13 +49,20 @@ def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> 
     return decorate
 
 
-def deprecated(replacement: str = None, version: str = None, msg: str = None):
+def deprecated(replacement: str = None, version: str = None, date: str = None, msg: str = None):
     def decorate(func: Callable) -> Callable:
+        if date is not None and version is not None:
+            raise ValueError("Expected removal timeframe can either be a date, or a version, not both.")
+
         # Construct and send the warning message
         name = getattr(func, "__qualname__", func.__name__)
-        warn_message = f"'{name}' is deprecated and will be removed"
+        warn_message = f"'{name}' is deprecated and is expected to be removed"
         if version is not None:
             warn_message += f" in {version}"
+        elif date is not None:
+            warn_message += f" in {date}"
+        else:
+            warn_message += " eventually"
         if replacement is not None:
             warn_message += f", use '{replacement}' instead"
         warn_message += "."

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -77,7 +77,7 @@ def deprecated(
         if version is not None:
             warn_message += f" in {version}"
         elif date is not None:
-            warn_message += f" in {date}"
+            warn_message += f" on {date}"
         else:
             warn_message += " eventually"
         if replacement is not None:

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -64,12 +64,12 @@ def deprecated(
     def decorate_func(func: Callable, warn_message: str):
         @wraps(func)
         def sync_wrapper(*args, **kwargs):
-            warnings.warn(warn_message)
+            warnings.warn(warn_message, category=DeprecationWarning)
             return func(*args, **kwargs)
 
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
-            warnings.warn(warn_message)
+            warnings.warn(warn_message, category=DeprecationWarning)
             return await func(*args, **kwargs)
 
         if asyncio.iscoroutinefunction(func):

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from functools import wraps
 from typing import Callable, Tuple, Type
 
@@ -40,6 +41,36 @@ def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> 
                     last_exc = exc
             else:
                 raise last_exc  # type: ignore # (This won't actually be unbound)
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper
+        return sync_wrapper
+
+    return decorate
+
+
+def deprecated(replacement: str = None, version: str = None, msg: str = None):
+    def decorate(func: Callable) -> Callable:
+        # Construct and send the warning message
+        name = getattr(func, "__qualname__", func.__name__)
+        warn_message = f"'{name}' is deprecated and will be removed"
+        if version is not None:
+            warn_message += f" in {version}"
+        if replacement is not None:
+            warn_message += f", use '{replacement}' instead"
+        warn_message += "."
+        if msg is not None:
+            warn_message += f" ({msg})"
+
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            warnings.warn(warn_message)
+            return func(*args, **kwargs)
+
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            warnings.warn(warn_message)
+            return await func(*args, **kwargs)
 
         if asyncio.iscoroutinefunction(func):
             return async_wrapper


### PR DESCRIPTION
As was already [discussed on the discord server](https://discord.com/channels/936788458939224094/936788458939224097/938236414716428308), we decided that it would be a good idea to rename `MinecraftServer` to `JavaServer` instead, since the reason for naming it `MinecraftServer` was purely because this library was made before bedrock edition even existed so there was no confusion, however now, that's not the case anymore and it's very odd to have `MinecraftServer` and `MinecraftBedrockServer` classes, with `MinecraftServer` being used for the java version.

This also drops the `Minecraft` prefix from these classes (`MinecraftBedrockServer` becomes `BedrockServer`) since we've decided that there's no point in keeping it either as in most cases, it will be obvious what these names are referring to, and if there was a conflict somewhere, people can always use an import as statement (`from mcstatus import JavaServer as MinecraftJavaServer`)

To preserve backwards compatibility, I've added simple classes which inherit from these new ones, having the original names. These classes will produce deprecation warnings if used.

Note: I can add a version of removal for the deprecated classes if desired, however I didn't mention it because I had no idea what version to pass, if we want to add this, which version should I use?

Blocked by:
- [x] #232