### PR TITLE
Only start workflows on pushes to master

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -1,6 +1,10 @@
 name: Tox test
 
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 env:
   # Make sure pip caches dependencies and installs as user

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,6 +1,10 @@
 name: Validation
 
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 env:
   # Make sure pip caches dependencies and installs as user


### PR DESCRIPTION
Since we're treating other branches as feature branches, there's no reason to run workflows on them up until they're in a PR. GitHub does limit the amount of concurrent workflows which we can run and having these workflows run on both pull request and push on any branch can mean that if that PR is made from a local feature branch, we're running the checks twice for no reason (once on push to local branch, and once on PR).

To avoid this, this PR changes this behavior and only runs the workflows on pull requests, or to pushes to master branch, bot not to any other branch.