### PR TITLE
Don't run pyright on files from .tox environemnt

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -3,6 +3,9 @@
         // Don't type-check files in the virtual environment, it contains
         // external library code which we don't need to check
         ".venv",
+        // Tox makes it's own environments, we don't want to check files
+        // in these either
+        ".tox",
         // GitHub validation workflow creates .cache folder to store the 
         // python environment into, we don't want to check the files in it
         // for the same reason as with venv


### PR DESCRIPTION
Without this, when `.tox` folder is present with the virtual environment constructed by tox, pyright attempts to check every file in it. This prevents that and adds `.tox` to the excluded paths.

**Blocked by:**
- [x] #229 
- [ ] #232