### PR TITLE
Reset python environment cache for tox-test workflow

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -53,7 +53,7 @@ jobs:
           path: |
             ${{ env.PYTHONUSERBASE }}
             ${{ env.TOXDIR }}
-          key: "python-0-${{ runner.os }}-${{ env.PYTHONUSERBASE }}-\
+          key: "python-1-${{ runner.os }}-${{ env.PYTHONUSERBASE }}-\
                 ${{ env.TOXDIR }}-${{ steps.python.outputs.python-version }}-\
                 ${{ hashFiles('./pyproject.toml', './poetry.lock') }}"
 


### PR DESCRIPTION
For some reason, the `tox-test` workflow for windows on python 3.7 suddenly started to fail, with it complaining about a missing `zipp` module. This is seems to be an indirect dependency of both `tox` and `pytest`.

I've no idea why it would keep on working for quite a while now, and suddenly just start to fail. However resetting the cache does seem to fix things, so this makes a quick and dirty change to the cache key, forcing a reset.

If anyone has any idea on why this occurred, please let me know on discord or by commenting here, since I have absolutely no idea what went wrong.