### PR TITLE
Run command for generating payload with bash

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -83,6 +83,7 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         continue-on-error: true
         run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
+        shell: bash
 
       # This only makes sense if the previous step succeeded. To
       # get the original outcome of the previous step before the


### PR DESCRIPTION
In #220, I've added a new job to the `tox-lint` workflow which generates an artifact which we then upload and is used from the `status-embed` workflow. However in that PR, I didn't notice that this generation was failing for windows each time. This is happening since the job was running a command which couldn't be executed on powershell. This PR fixes that by explicitly stating that the shell for this command should be `bash`, even on windows.

This isn't something critical since this workflow artifact generation job isn't required for the workflow to pass, but it should be fixed to avoid not being able to access some details about the workflow later in the `status-embed` job.

**Blocked by:**
- [x] #229 
- [ ] #232 