### PR TITLE
Use RdataType enum for dns types

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -4,6 +4,7 @@ from typing import Optional, TYPE_CHECKING, Tuple
 from urllib.parse import urlparse
 
 import dns.resolver
+from dns.rdatatype import RdataType
 from dns.exception import DNSException
 
 from mcstatus.bedrock_status import BedrockServerStatus, BedrockStatusResponse
@@ -70,7 +71,7 @@ class MinecraftServer:
         if port is None:
             port = 25565
             try:
-                answers = dns.resolver.resolve("_minecraft._tcp." + host, "SRV")
+                answers = dns.resolver.resolve("_minecraft._tcp." + host, RdataType.SRV)
                 if len(answers):
                     answer = answers[0]
                     host = str(answer.target).rstrip(".")
@@ -163,7 +164,7 @@ class MinecraftServer:
         """
         host = self.host
         try:
-            answers = dns.resolver.resolve(host, "A")
+            answers = dns.resolver.resolve(host, RdataType.A)
             if len(answers):
                 answer = answers[0]
                 host = str(answer).rstrip(".")
@@ -187,7 +188,7 @@ class MinecraftServer:
         """
         host = self.host
         try:
-            answers = dns.resolver.resolve(host, "A")
+            answers = dns.resolver.resolve(host, RdataType.A)
             if len(answers):
                 answer = answers[0]
                 host = str(answer).rstrip(".")

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -4,8 +4,8 @@ from typing import Optional, TYPE_CHECKING, Tuple
 from urllib.parse import urlparse
 
 import dns.resolver
-from dns.rdatatype import RdataType
 from dns.exception import DNSException
+from dns.rdatatype import RdataType
 
 from mcstatus.bedrock_status import BedrockServerStatus, BedrockStatusResponse
 from mcstatus.pinger import AsyncServerPinger, PingResponse, ServerPinger

--- a/mcstatus/tests/test_server.py
+++ b/mcstatus/tests/test_server.py
@@ -3,6 +3,7 @@ import sys
 from unittest.mock import Mock, patch
 
 import pytest
+from dns.rdatatype import RdataType
 
 from mcstatus.protocol.connection import Connection
 from mcstatus.server import MinecraftServer
@@ -15,7 +16,7 @@ class MockProtocolFactory(asyncio.Protocol):
         self.data_expected_to_receive = data_expected_to_receive
         self.data_to_respond_with = data_to_respond_with
 
-    def connection_made(self, transport):
+    def connection_made(self, transport: asyncio.Transport):
         print("connection_made")
         self.transport = transport
 
@@ -178,7 +179,7 @@ class TestMinecraftServer:
         with patch("dns.resolver.resolve") as resolve:
             resolve.return_value = []
             self.server = MinecraftServer.lookup("example.org")
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", "SRV")
+            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV)
         assert self.server.host == "example.org"
         assert self.server.port == 25565
 
@@ -186,7 +187,7 @@ class TestMinecraftServer:
         with patch("dns.resolver.resolve") as resolve:
             resolve.side_effect = [Exception]
             self.server = MinecraftServer.lookup("example.org")
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", "SRV")
+            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV)
         assert self.server.host == "example.org"
         assert self.server.port == 25565
 
@@ -197,7 +198,7 @@ class TestMinecraftServer:
             answer.port = 12345
             resolve.return_value = [answer]
             self.server = MinecraftServer.lookup("example.org")
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", "SRV")
+            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV)
         assert self.server.host == "different.example.org"
         assert self.server.port == 12345
 


### PR DESCRIPTION
The `dns.resolver.resolve` function accepts both a string DNS type and `RdataType` enumeration class value.
Even though both are supported, we should always prefer an enumeration type, if there is one.

This also fixes a typing error, which didn't previously occur until version 1.1.224 of pyright was [published](https://github.com/microsoft/pyright/releases/tag/1.1.224). After that, pyright started to detect this as an issue, which then caused our Validation workflow to start failing. This means that this until this PR is merged, this workflow will keep failing everywhere. For discussion about addressing this behavior, see #233.