### PR TITLE
Fix issues with deprecated decorator

### DIFF
--- a/mcstatus/tests/test_deprecated_decorator.py
+++ b/mcstatus/tests/test_deprecated_decorator.py
@@ -6,7 +6,7 @@ from mcstatus.utils import deprecated
 
 
 def test_deprecated_function_produces_warning():
-    f = deprecated(lambda: None)
+    f = deprecated()(lambda: None)
 
     with warnings.catch_warnings(record=True) as w:
         f()
@@ -15,7 +15,7 @@ def test_deprecated_function_produces_warning():
 
 
 def test_deprecated_class_produces_warning():
-    dep_cls = deprecated(type("TestCls", (), {"foo": lambda: None}), methods=["foo"])
+    dep_cls = deprecated(methods=["foo"])(type("TestCls", (), {"foo": lambda: None}))
 
     with warnings.catch_warnings(record=True) as w:
         dep_cls.foo()
@@ -24,7 +24,7 @@ def test_deprecated_class_produces_warning():
 
 
 def test_deprecated_function_return_result():
-    f = deprecated(lambda x: x)
+    f = deprecated()(lambda x: x)
 
     with warnings.catch_warnings():
         result = f(10)
@@ -33,7 +33,7 @@ def test_deprecated_function_return_result():
 
 
 def test_deprecated_class_return_result():
-    dep_cls = deprecated(type("TestCls", (), {"foo": lambda x: x}), methods=["foo"])
+    dep_cls = deprecated(methods=["foo"])(type("TestCls", (), {"foo": lambda x: x}))
 
     with warnings.catch_warnings():
         result = dep_cls.foo(10)
@@ -43,12 +43,12 @@ def test_deprecated_class_return_result():
 
 def test_deprecated_function_with_methods():
     with pytest.raises(ValueError):
-        deprecated(lambda: None, methods=["__str__"])
+        deprecated(methods=["__str__"])(lambda: None)
 
 
 def test_deprecated_class_without_methods():
     with pytest.raises(ValueError):
-        deprecated(type("TestCls", (), {"foo": lambda x: x}))
+        deprecated()(type("TestCls", (), {"foo": lambda x: x}))
 
 
 @pytest.mark.parametrize(
@@ -63,7 +63,7 @@ def test_deprecated_class_without_methods():
     ],
 )
 def test_deprecated_arguments(arguments):
-    f = deprecated(lambda: None, **arguments)
+    f = deprecated(**arguments)(lambda: None)
 
     with warnings.catch_warnings(record=True) as w:
         f()

--- a/mcstatus/tests/test_deprecated_decorator.py
+++ b/mcstatus/tests/test_deprecated_decorator.py
@@ -71,3 +71,21 @@ def test_deprecated_arguments(arguments):
 
         for value in arguments.values():
             assert value in warning_message
+
+
+def test_deprecated_no_call_decorator():
+    """This makes sure deprecated decorator can run directly on a function without first being called.
+
+    Usually we use deprecated decorator with arguments like @deprecated(msg='hi'), however this means
+    that using it normally would usually require doing @deprecated(), but since all of the arguments
+    are optional, we can also support using @deprecated, without calling it first. This tests that
+    this behavior is in fact working.
+    """
+    f = deprecated(lambda x: x)
+
+    with warnings.catch_warnings(record=True) as w:
+        result = f(10)
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message).lower()
+
+    assert result == 10

--- a/mcstatus/tests/test_deprecated_decorator.py
+++ b/mcstatus/tests/test_deprecated_decorator.py
@@ -1,0 +1,73 @@
+import warnings
+
+import pytest
+
+from mcstatus.utils import deprecated
+
+
+def test_deprecated_function_produces_warning():
+    f = deprecated(lambda: None)
+
+    with warnings.catch_warnings(record=True) as w:
+        f()
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message).lower()
+
+
+def test_deprecated_class_produces_warning():
+    dep_cls = deprecated(type("TestCls", (), {"foo": lambda: None}), methods=["foo"])
+
+    with warnings.catch_warnings(record=True) as w:
+        dep_cls.foo()
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message).lower()
+
+
+def test_deprecated_function_return_result():
+    f = deprecated(lambda x: x)
+
+    with warnings.catch_warnings():
+        result = f(10)
+
+    assert result == 10
+
+
+def test_deprecated_class_return_result():
+    dep_cls = deprecated(type("TestCls", (), {"foo": lambda x: x}), methods=["foo"])
+
+    with warnings.catch_warnings():
+        result = dep_cls.foo(10)
+
+    assert result == 10
+
+
+def test_deprecated_function_with_methods():
+    with pytest.raises(ValueError):
+        deprecated(lambda: None, methods=["__str__"])
+
+
+def test_deprecated_class_without_methods():
+    with pytest.raises(ValueError):
+        deprecated(type("TestCls", (), {"foo": lambda x: x}))
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"replacement": "library.newfunction"},
+        {"version": "4.8.1"},
+        {"date": "2022-06"},
+        {"msg": "Why would you still use this?"},
+        {"replacement": "new_function", "version": "0.1.2", "msg": "Function got renamed"},
+        {"replacement": "new_function", "date": "2022-11", "msg": "Function got renamed"},
+    ],
+)
+def test_deprecated_arguments(arguments):
+    f = deprecated(lambda: None, **arguments)
+
+    with warnings.catch_warnings(record=True) as w:
+        f()
+        warning_message = str(w[-1].message)
+
+        for value in arguments.values():
+            assert value in warning_message

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -65,7 +65,9 @@ def deprecated(
     def decorate_func(func: Callable, warn_message: str):
         @wraps(func)
         def wrapper(*args, **kwargs):
+            warnings.simplefilter("always", DeprecationWarning)
             warnings.warn(warn_message, category=DeprecationWarning)
+            warnings.simplefilter("default", DeprecationWarning)
             return func(*args, **kwargs)
 
         return wrapper

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -123,16 +123,18 @@ def deprecated(
         if msg is not None:
             warn_message += f" ({msg})"
 
+        # If we're deprecating class, deprecate it's methods and return the class
         if inspect.isclass(obj):
             if methods is None:
                 raise ValueError("When deprecating a class, you need to specify 'methods' which will get the notice")
 
-            # Decorate every specified method of given class
             for method in methods:
                 new_func = decorate_func(getattr(obj, method), warn_message)
                 setattr(obj, method, new_func)
+
             return obj
 
+        # Regular function deprecation
         if methods is not None:
             raise ValueError("Methods can only be specified when decorating a class, not a function")
         return decorate_func(obj, warn_message)


### PR DESCRIPTION
This fixes several issues with the deprecated decorator:

- **Warnings weren't being produced**. Apparently, `warnings.warn` uses stacklevel=1 by default, which means it only produces a warning if it's called directly. To fix this, we could simply increase this level to cover the amount of function calls to get to this warnning, that would still mean people who aren't using our functions directly wouldn't get the warnings. So instead, I fixed this by simply setting `warnings.simplefilter` to `always`, produce the warning and then reset the filter back.
- **This decorator didn't have any test coverage**. If the decorator was properly tested initially, the above issue would never have occurred, so this also adds tests for this decorator to prevent any future ones.
- **The decorator wasn't properly type-annotated**. The decorator function lacked a return type of `Callable` leading to some typing issues. While this could've been fixed by simply adding this return type, in that case we wouldn't preserve the original arguments of the decorated functions, which isn't great, so instead, this adds a complete solution utilizing `ParamSpec` to implement this.
- **Minor commenting improvements**.