### PR TITLE
Use renamed server classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ We provide both an API which you can use in your projects, and a command line sc
 
 Java Edition
 ```python
-from mcstatus import MinecraftServer
+from mcstatus import JavaServer
 
 # You can pass the same address you'd enter into the address field in minecraft into the 'lookup' function
-# If you know the host and port, you may skip this and use MinecraftServer("example.org", 1234)
-server = MinecraftServer.lookup("example.org:1234")
+# If you know the host and port, you may skip this and use JavaServer("example.org", 1234)
+server = JavaServer.lookup("example.org:1234")
 
 # 'status' is supported by all Minecraft servers that are version 1.7 or higher.
 status = server.status()
@@ -39,11 +39,11 @@ print(f"The server has the following players online: {', '.join(query.players.na
 
 Bedrock Edition
 ```python
-from mcstatus import MinecraftBedrockServer
+from mcstatus import BedrockServer
 
 # You can pass the same address you'd enter into the address field in minecraft into the 'lookup' function
 # If you know the host and port, you may skip this and use MinecraftBedrockServer("example.org", 19132)
-server = MinecraftBedrockServer.lookup("example.org:19132")
+server = BedrockServer.lookup("example.org:19132")
 
 # 'status' is the only feature that is supported by Bedrock at this time.
 # In this case status includes players_online, latency, motd, map, gamemode, and players_max. (ex: status.gamemode)

--- a/mcstatus/scripts/mcstatus.py
+++ b/mcstatus/scripts/mcstatus.py
@@ -5,9 +5,9 @@ from json import dumps as json_dumps
 
 import click
 
-from mcstatus import MinecraftServer
+from mcstatus import JavaServer
 
-server: MinecraftServer = None  # type: ignore[assignment]  # This will be set with cli function
+server: JavaServer = None  # type: ignore[assignment]  # This will be set with cli function
 
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
@@ -43,7 +43,7 @@ def cli(address):
     players: 1/20 ['Dinnerbone (61699b2e-d327-4a01-9f1e-0ea8c3f06bc6)']
     """
     global server
-    server = MinecraftServer.lookup(address)
+    server = JavaServer.lookup(address)
 
 
 @cli.command(short_help="prints server latency")


### PR DESCRIPTION
In PR #222 , we have renamed the `MinecraftServer` class to `JavaServer`, and `MinecraftBedrockServer` to `BedrockServer`. However there were still some places left that used these now deprecated old names, which this PR addresses.