### PR TITLE
Resolve TODO about Mac OS failing tests

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import warnings
 from abc import ABC
 from typing import TYPE_CHECKING
-
-import dns.resolver
 
 from mcstatus.address import Address, async_minecraft_srv_address_lookup, minecraft_srv_address_lookup
 from mcstatus.bedrock_status import BedrockServerStatus, BedrockStatusResponse
@@ -165,15 +162,7 @@ class JavaServer(MCServer):
 
     def query(self) -> QueryResponse:
         """Checks the status of a Minecraft Java Edition server via the query protocol."""
-        # TODO: WARNING: This try-except for NXDOMAIN is only done because
-        # of failing tests on mac-os, which for some reason can't resolve 'localhost'
-        # into '127.0.0.1'. This try-except needs to be removed once this issue
-        # is resolved!
-        try:
-            ip = str(self.address.resolve_ip())
-        except dns.resolver.NXDOMAIN:
-            warnings.warn(f"Resolving IP for {self.address.host} failed with NXDOMAIN")
-            ip = self.address.host
+        ip = str(self.address.resolve_ip())
 
         return self._retry_query(Address(ip, self.address.port))
 
@@ -186,15 +175,7 @@ class JavaServer(MCServer):
 
     async def async_query(self) -> QueryResponse:
         """Asynchronously checks the status of a Minecraft Java Edition server via the query protocol."""
-        # TODO: WARNING: This try-except for NXDOMAIN is only done because
-        # of failing tests on mac-os, which for some reason can't resolve 'localhost'
-        # into '127.0.0.1'. This try-except needs to be removed once this issue
-        # is resolved!
-        try:
-            ip = str(await self.address.async_resolve_ip())
-        except dns.resolver.NXDOMAIN:
-            warnings.warn(f"Resolving IP for {self.address.host} failed with NXDOMAIN")
-            ip = self.address.host
+        ip = str(await self.address.async_resolve_ip())
 
         return await self._retry_async_query(Address(ip, self.address.port))
 


### PR DESCRIPTION
This actually applied to multiple operating systems, but required using a DNS server that answers to queries about localhost. Responding to those with anything but NXDOMAIN violates the DNS RFC, so it's surprising to see this be so rampant out in the wild. Anyway, the solution is to use `getaddrinfo` to let the OS stack handle resolution of names.