### PR TITLE
Fix typing issue in deprecated decorator

### DIFF
--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -170,6 +170,7 @@ def deprecated(
             return obj
 
         # Regular function deprecation
+        obj = cast(Callable[P, R], obj)
         if methods is not None:
             raise ValueError("Methods can only be specified when decorating a class, not a function")
         return decorate_func(obj, warn_message)

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     P2 = ParamSpec("P2")
 else:
     Protocol = object
+    P = []
 
 T = TypeVar("T")
 R = TypeVar("R")


### PR DESCRIPTION
This fixes a pyright issue which appeared in the next pyright release in the deprecated decorator, fixes #315 failing validation workflow.