### PR TITLE
Remove always warning filters from deprecated

### DIFF
--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -125,9 +125,7 @@ def deprecated(
     def decorate_func(func: Callable[P2, R2], warn_message: str) -> Callable[P2, R2]:
         @wraps(func)
         def wrapper(*args: P2.args, **kwargs: P2.kwargs) -> R2:
-            warnings.simplefilter("always", DeprecationWarning)
-            warnings.warn(warn_message, category=DeprecationWarning)
-            warnings.simplefilter("default", DeprecationWarning)
+            warnings.warn(warn_message, category=DeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
Brought up in [this discord discussion](https://discord.com/channels/936788458939224094/938623566964981802/980018466394353724)

The deprecated decorator was explicitly overriding `warnings.simplefilter` to always show the deprecation warnings. This behavior was introduced in #265 as a fix because the warnings weren't being shown without it. This was happening due to the default warning `stacklevel` of 1.

However doing this made it impossible to explicitly ignore these warnings using the simplefilter, making things like`pytest.mark.filterwarnings("ignore::DeprecationWarning")` useless.

This removes these added overrides to simplefilter and instead simply uses stacklevel of 2, which should always trace back to the deprecated decorator being called. That said, more thorough testing should probably be done during the review process before this gets merged, to ensure that no matter where and how this decorator is used, the warning will be produced with the stacklevel of 2.