### PR TITLE
Parse color formatting codes in description before other formatting

### DIFF
--- a/mcstatus/pinger.py
+++ b/mcstatus/pinger.py
@@ -9,10 +9,6 @@ from mcstatus.address import Address
 from mcstatus.protocol.connection import Connection, TCPAsyncSocketConnection, TCPSocketConnection
 
 STYLE_MAP = {
-    "bold": "l",
-    "italic": "o",
-    "underlined": "n",
-    "obfuscated": "k",
     "color": {
         "dark_red": "4",
         "red": "c",
@@ -31,6 +27,10 @@ STYLE_MAP = {
         "dark_gray": "8",
         "black": "0",
     },
+    "bold": "l",
+    "italic": "o",
+    "underlined": "n",
+    "obfuscated": "k",
 }
 
 


### PR DESCRIPTION
In Java Edition Minecraft, using a color code after other formatting will reset it.
Adding formatting symbols for non-colors first causes descriptions which do not render
non-color formatting that is colored at the same time.

For example a server with the raw description of:
```json
{"extra": [{"bold": true, "underlined": true, "color": "light_purple", "text": "Silly"}], "text": ""}
```
Would look like:
![image](https://user-images.githubusercontent.com/9390699/174421462-eafc3acb-e85f-4867-97e8-c925a2f337fb.png)
But has a description value of `§l§n§dSilly` (bold, underlined, light_purple).
Which normally renders without the bold and underline as the color after it resets that:
![image](https://user-images.githubusercontent.com/9390699/174421500-264400fe-5082-494a-8eac-95aa4c37a377.png)

Processing the colors first causes it to be `§d§l§nSilly` instead which renders correctly and does not remove the bold or underline.

