### PR TITLE
Add coveragerc to ignore type-time only lines

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    pragma: nocover
+    if TYPE_CHECKING:

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.coverage*
+.coverage
 .cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
This adds `.coveragerc` file which is used to configure coverage reports from unit tests. This file adds configuration which automatically ignores all lines under `if TYPE_CHECKING:`, without having to use a special `# pragma: nocover` comment. 

This will save a lot of repetition and will improve the accuracy of our coverage reports as we never want need to verify unit-tests covering typing-time only definitions, which will never be executed on runtime.