### PR TITLE
Require annotations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,10 +6,9 @@ ban-relative-imports=true
 import-order-style=pycharm
 exclude=.venv,.git,.cache,.tox
 ignore=
-    ANN001, # TEMPORARY: parameter annotation (we still have a lot of these)
-    ANN201, # TEMPORARY: return type annotation (we still have a lot of these)
     ANN002, # *args annotation
     ANN003, # **kwargs annotation
     ANN101, # self param annotation
     ANN102, # cls param annotation
     ANN204, # return type annotation for special methods
+per-file-ignores=test_*.py:ANN

--- a/mcstatus/__main__.py
+++ b/mcstatus/__main__.py
@@ -12,7 +12,7 @@ server: JavaServer = None  # type: ignore[assignment]  # This will be set with c
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.argument("address")
-def cli(address):
+def cli(address: str) -> None:
     """
     mcstatus provides an easy way to query Minecraft servers for
     any information they can expose. It provides three modes of
@@ -47,7 +47,7 @@ def cli(address):
 
 
 @cli.command(short_help="prints server latency")
-def ping():
+def ping() -> None:
     """
     Ping server for latency.
     """
@@ -55,7 +55,7 @@ def ping():
 
 
 @cli.command(short_help="basic server information")
-def status():
+def status() -> None:
     """
     Prints server status. Supported by all Minecraft
     servers that are version 1.7 or higher.
@@ -72,7 +72,7 @@ def status():
 
 
 @cli.command(short_help="all available server information in json")
-def json():
+def json() -> None:
     """
     Prints server status and query in json. Supported by all Minecraft
     servers that are version 1.7 or higher.
@@ -106,7 +106,7 @@ def json():
 
 
 @cli.command(short_help="detailed server information")
-def query():
+def query() -> None:
     """
     Prints detailed server information. Must be enabled in
     servers' server.properties file.

--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -277,7 +277,7 @@ class TCPAsyncSocketConnection(AsyncReadConnection):
     def __init__(self):
         super().__init__()
 
-    async def connect(self, addr: Address, timeout: float = 3):
+    async def connect(self, addr: Address, timeout: float = 3) -> None:
         self.timeout = timeout
         conn = asyncio.open_connection(addr[0], addr[1])
         self.reader, self.writer = await asyncio.wait_for(conn, timeout=self.timeout)
@@ -309,7 +309,7 @@ class UDPAsyncSocketConnection(AsyncReadConnection):
     def __init__(self):
         super().__init__()
 
-    async def connect(self, addr: Address, timeout: float = 3):
+    async def connect(self, addr: Address, timeout: float = 3) -> None:
         self.timeout = timeout
         conn = asyncio_dgram.connect((addr[0], addr[1]))
         self.stream = await asyncio.wait_for(conn, timeout=self.timeout)

--- a/mcstatus/querier.py
+++ b/mcstatus/querier.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 import re
 import struct
-from typing import Dict, List, TYPE_CHECKING
+from typing import Dict, List, TYPE_CHECKING, Union
 
 from mcstatus.protocol.connection import Connection, UDPAsyncSocketConnection, UDPSocketConnection
 
@@ -96,7 +96,8 @@ class QueryResponse:
         max: int
         names: List[str]
 
-        def __init__(self, online, max, names):
+        # TODO: It's a bit weird that we accept str for number parameters, just to convert them in init
+        def __init__(self, online: Union[str, int], max: Union[str, int], names: List[str]):
             self.online = int(online)
             self.max = int(max)
             self.names = names
@@ -106,7 +107,7 @@ class QueryResponse:
         brand: str
         plugins: List[str]
 
-        def __init__(self, version, plugins):
+        def __init__(self, version: str, plugins: str):
             self.version = version
             self.brand = "vanilla"
             self.plugins = []

--- a/mcstatus/tests/test_pinger.py
+++ b/mcstatus/tests/test_pinger.py
@@ -276,7 +276,7 @@ class TestPingResponse:
 class TestPingResponsePlayers:
     def test_invalid(self):
         with pytest.raises(ValueError):
-            PingResponse.Players("foo")
+            PingResponse.Players("foo")  # type: ignore # (Intentionally incorrect type)
 
     def test_max_missing(self):
         with pytest.raises(ValueError):
@@ -324,7 +324,7 @@ class TestPingResponsePlayers:
 class TestPingResponsePlayersPlayer:
     def test_invalid(self):
         with pytest.raises(ValueError):
-            PingResponse.Players.Player("foo")
+            PingResponse.Players.Player("foo")  # type: ignore # (Intentionally incorrect type)
 
     def test_name_missing(self):
         with pytest.raises(ValueError):
@@ -352,7 +352,7 @@ class TestPingResponsePlayersPlayer:
 class TestPingResponseVersion:
     def test_invalid(self):
         with pytest.raises(ValueError):
-            PingResponse.Version("foo")
+            PingResponse.Version("foo")  # type: ignore # (Intentionally incorrect type)
 
     def test_protocol_missing(self):
         with pytest.raises(ValueError):

--- a/mcstatus/tests/test_timeout.py
+++ b/mcstatus/tests/test_timeout.py
@@ -24,7 +24,7 @@ class TestAsyncSocketConnection:
 
     def test_tcp_socket_read(self):
         try:
-            from asyncio.exceptions import TimeoutError
+            from asyncio.exceptions import TimeoutError  # type: ignore # (Import for older versions)
         except ImportError:
             from asyncio import TimeoutError
 


### PR DESCRIPTION
This finally removes the temporarily added exceptions to `flake8-annotations` allowing some functions to remain without type-hints in #212.

To remove this exception, this PR also adds type-hints to all functions in the code-base which weren't previously annotated. 

Note that the reason why I initially didn't annotate these functions in #212 was to because of some poor design choices, or python's lack of typing support for some things. This meant that even though I did manage to add annotations everywhere, it required a lot of type ignores and explicit casts for the code to still pass type-wise (without cheating with `typing.Any`). 

If this is too much "eye-sore", It's also possible to handle this with flake8 noqa ignores for these annoying functions.