### PR TITLE
Add a default value for default_port

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -57,7 +57,7 @@ class MCServer(ABC):
         :param str address: The address of the Minecraft server, like `example.com:19132`
         :param float timeout: The timeout in seconds before failing to connect.
         """
-        addr = Address.parse_address(address, default_port=None)
+        addr = Address.parse_address(address, default_port=19132)
         return cls(addr.host, addr.port, timeout=timeout)
 
 


### PR DESCRIPTION
When the server uses the default port of 19132, we should be allowed to omit the port number
```
>>> bs.lookup("example.org")
ValueError: Given address 'example.org' doesn't contain port and default_port wasn't specified, can't parse.
```