### PR TITLE
Set default ports

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -68,7 +68,7 @@ class MCServer(ABC):
 class JavaServer(MCServer):
     """Base class for a Minecraft Java Edition server."""
 
-    DEFAULT_PORT: int = 25565
+    DEFAULT_PORT = 25565
 
     @classmethod
     def lookup(cls, address: str, timeout: float = 3) -> Self:
@@ -212,7 +212,7 @@ class JavaServer(MCServer):
 class BedrockServer(MCServer):
     """Base class for a Minecraft Bedrock Edition server."""
 
-    DEFAULT_PORT: int = 19132
+    DEFAULT_PORT = 19132
 
     @retry(tries=3)
     def status(self, **kwargs) -> BedrockStatusResponse:

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -36,9 +36,11 @@ class MCServer(ABC):
     :param float timeout: The timeout in seconds before failing to connect.
     """
 
-    default_port: Optional[int] = None
+    default_port: int
 
-    def __init__(self, host: str, port: int, timeout: float = 3):
+    def __init__(self, host: str, port: Optional[int] = None, timeout: float = 3):
+        if port is None:
+            port = self.default_port
         self.address = Address(host, port)
         self.timeout = timeout
 
@@ -67,10 +69,6 @@ class JavaServer(MCServer):
     """Base class for a Minecraft Java Edition server."""
 
     default_port: int = 25565
-
-    def __init__(self, host: str, port: int = default_port, timeout: float = 3):
-        """Override init to add a default port for java servers of 25565."""
-        super().__init__(host, port, timeout=timeout)
 
     @classmethod
     def lookup(cls, address: str, timeout: float = 3) -> Self:
@@ -215,10 +213,6 @@ class BedrockServer(MCServer):
     """Base class for a Minecraft Bedrock Edition server."""
 
     default_port: int = 19132
-
-    def __init__(self, host: str, port: int = default_port, timeout: float = 3):
-        """Override init to add a default port for bedrock servers of 19132."""
-        super().__init__(host, port, timeout=timeout)
 
     @retry(tries=3)
     def status(self, **kwargs) -> BedrockStatusResponse:

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 import dns.resolver
 
@@ -36,6 +36,8 @@ class MCServer(ABC):
     :param float timeout: The timeout in seconds before failing to connect.
     """
 
+    default_port: Optional[int] = None
+
     def __init__(self, host: str, port: int, timeout: float = 3):
         self.address = Address(host, port)
         self.timeout = timeout
@@ -57,14 +59,16 @@ class MCServer(ABC):
         :param str address: The address of the Minecraft server, like `example.com:19132`
         :param float timeout: The timeout in seconds before failing to connect.
         """
-        addr = Address.parse_address(address, default_port=None)
+        addr = Address.parse_address(address, default_port=cls.default_port)
         return cls(addr.host, addr.port, timeout=timeout)
 
 
 class JavaServer(MCServer):
     """Base class for a Minecraft Java Edition server."""
 
-    def __init__(self, host: str, port: int = 25565, timeout: float = 3):
+    default_port: int = 25565
+
+    def __init__(self, host: str, port: int = default_port, timeout: float = 3):
         """Override init to add a default port for java servers of 25565."""
         super().__init__(host, port, timeout=timeout)
 
@@ -80,7 +84,7 @@ class JavaServer(MCServer):
         :param str address: The address of the Minecraft server, like `example.com:25565`.
         :param float timeout: The timeout in seconds before failing to connect.
         """
-        addr = minecraft_srv_address_lookup(address, default_port=25565, lifetime=timeout)
+        addr = minecraft_srv_address_lookup(address, default_port=cls.default_port, lifetime=timeout)
         return cls(addr.host, addr.port, timeout=timeout)
 
     @classmethod
@@ -89,7 +93,7 @@ class JavaServer(MCServer):
 
         For more details, check the docstring of the synchronous lookup function.
         """
-        addr = await async_minecraft_srv_address_lookup(address, default_port=25565, lifetime=timeout)
+        addr = await async_minecraft_srv_address_lookup(address, default_port=cls.default_port, lifetime=timeout)
         return cls(addr.host, addr.port, timeout=timeout)
 
     def ping(self, **kwargs) -> float:
@@ -210,7 +214,9 @@ class JavaServer(MCServer):
 class BedrockServer(MCServer):
     """Base class for a Minecraft Bedrock Edition server."""
 
-    def __init__(self, host: str, port: int = 19132, timeout: float = 3):
+    default_port: int = 19132
+
+    def __init__(self, host: str, port: int = default_port, timeout: float = 3):
         """Override init to add a default port for bedrock servers of 19132."""
         super().__init__(host, port, timeout=timeout)
 

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -36,11 +36,11 @@ class MCServer(ABC):
     :param float timeout: The timeout in seconds before failing to connect.
     """
 
-    default_port: int
+    DEFAULT_PORT: int
 
     def __init__(self, host: str, port: Optional[int] = None, timeout: float = 3):
         if port is None:
-            port = self.default_port
+            port = self.DEFAULT_PORT
         self.address = Address(host, port)
         self.timeout = timeout
 
@@ -61,14 +61,14 @@ class MCServer(ABC):
         :param str address: The address of the Minecraft server, like `example.com:19132`
         :param float timeout: The timeout in seconds before failing to connect.
         """
-        addr = Address.parse_address(address, default_port=cls.default_port)
+        addr = Address.parse_address(address, default_port=cls.DEFAULT_PORT)
         return cls(addr.host, addr.port, timeout=timeout)
 
 
 class JavaServer(MCServer):
     """Base class for a Minecraft Java Edition server."""
 
-    default_port: int = 25565
+    DEFAULT_PORT: int = 25565
 
     @classmethod
     def lookup(cls, address: str, timeout: float = 3) -> Self:
@@ -82,7 +82,7 @@ class JavaServer(MCServer):
         :param str address: The address of the Minecraft server, like `example.com:25565`.
         :param float timeout: The timeout in seconds before failing to connect.
         """
-        addr = minecraft_srv_address_lookup(address, default_port=cls.default_port, lifetime=timeout)
+        addr = minecraft_srv_address_lookup(address, default_port=cls.DEFAULT_PORT, lifetime=timeout)
         return cls(addr.host, addr.port, timeout=timeout)
 
     @classmethod
@@ -91,7 +91,7 @@ class JavaServer(MCServer):
 
         For more details, check the docstring of the synchronous lookup function.
         """
-        addr = await async_minecraft_srv_address_lookup(address, default_port=cls.default_port, lifetime=timeout)
+        addr = await async_minecraft_srv_address_lookup(address, default_port=cls.DEFAULT_PORT, lifetime=timeout)
         return cls(addr.host, addr.port, timeout=timeout)
 
     def ping(self, **kwargs) -> float:
@@ -212,7 +212,7 @@ class JavaServer(MCServer):
 class BedrockServer(MCServer):
     """Base class for a Minecraft Bedrock Edition server."""
 
-    default_port: int = 19132
+    DEFAULT_PORT: int = 19132
 
     @retry(tries=3)
     def status(self, **kwargs) -> BedrockStatusResponse:

--- a/mcstatus/tests/test_server.py
+++ b/mcstatus/tests/test_server.py
@@ -82,6 +82,12 @@ class TestAsyncJavaServer:
         latency = await minecraft_server.async_ping(ping_token=29704774, version=47)
         assert latency >= 0
 
+    @pytest.mark.asyncio
+    async def test_async_lookup_constructor(self):
+        s = await JavaServer.async_lookup("example.org:25565")
+        assert s.address.host == "example.org"
+        assert s.address.port == 25565
+
 
 class TestJavaServer:
     def setup_method(self):
@@ -184,11 +190,5 @@ class TestJavaServer:
 
     def test_lookup_constructor(self):
         s = JavaServer.lookup("example.org:25565")
-        assert s.address.host == "example.org"
-        assert s.address.port == 25565
-
-    @pytest.mark.asyncio
-    async def test_async_lookup_constructor(self):
-        s = await JavaServer.async_lookup("example.org:25565")
         assert s.address.host == "example.org"
         assert s.address.port == 25565

--- a/mcstatus/tests/test_server.py
+++ b/mcstatus/tests/test_server.py
@@ -59,6 +59,12 @@ async def create_mock_packet_server(event_loop):
 
 
 class TestBedrockServer:
+    def setup_method(self):
+        self.server = BedrockServer("localhost")
+
+    def test_default_port(self):
+        assert self.server.address.port == 19132
+
     def test_lookup_constructor(self):
         s = BedrockServer.lookup("example.org")
         assert s.address.host == "example.org"
@@ -92,7 +98,10 @@ class TestAsyncJavaServer:
 class TestJavaServer:
     def setup_method(self):
         self.socket = Connection()
-        self.server = JavaServer("localhost", port=25565)
+        self.server = JavaServer("localhost")
+
+    def test_default_port(self):
+        assert self.server.address.port == 25565
 
     def test_ping(self):
         self.socket.receive(bytearray.fromhex("09010000000001C54246"))

--- a/mcstatus/tests/test_server.py
+++ b/mcstatus/tests/test_server.py
@@ -90,9 +90,9 @@ class TestAsyncJavaServer:
 
     @pytest.mark.asyncio
     async def test_async_lookup_constructor(self):
-        s = await JavaServer.async_lookup("example.org:25565")
+        s = await JavaServer.async_lookup("example.org:3333")
         assert s.address.host == "example.org"
-        assert s.address.port == 25565
+        assert s.address.port == 3333
 
 
 class TestJavaServer:
@@ -198,6 +198,6 @@ class TestJavaServer:
                 assert querier.call_count == 3
 
     def test_lookup_constructor(self):
-        s = JavaServer.lookup("example.org:25565")
+        s = JavaServer.lookup("example.org:4444")
         assert s.address.host == "example.org"
-        assert s.address.port == 25565
+        assert s.address.port == 4444

--- a/mcstatus/tests/test_server.py
+++ b/mcstatus/tests/test_server.py
@@ -6,7 +6,7 @@ import pytest
 import pytest_asyncio
 
 from mcstatus.protocol.connection import Connection
-from mcstatus.server import JavaServer
+from mcstatus.server import BedrockServer, JavaServer
 
 
 class MockProtocolFactory(asyncio.Protocol):
@@ -56,6 +56,13 @@ async def create_mock_packet_server(event_loop):
     for server in servers:
         server.close()
         await server.wait_closed()
+
+
+class TestBedrockServer:
+    def test_lookup_constructor(self):
+        s = BedrockServer.lookup("example.org")
+        assert s.address.host == "example.org"
+        assert s.address.port == 19132
 
 
 class TestAsyncJavaServer:


### PR DESCRIPTION
Add class attribute `default_port` to shave out some duplicate code and address the lack of a default in Bedrock's lookup method.