### PR TITLE
Remove deprecated `skipif` in tests

### DIFF
--- a/mcstatus/tests/test_server.py
+++ b/mcstatus/tests/test_server.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -72,10 +71,6 @@ class TestBedrockServer:
 
 
 class TestAsyncJavaServer:
-    @pytest.mark.skipif(
-        sys.platform.startswith("win"),
-        reason="async bug on Windows https://github.com/Dinnerbone/mcstatus/issues/140",
-    )
     @pytest.mark.asyncio
     async def test_async_ping(self, unused_tcp_port, create_mock_packet_server):
         await create_mock_packet_server(


### PR DESCRIPTION
Closes #140.