### PR TITLE
Pep 585

### DIFF
--- a/mcstatus/address.py
+++ b/mcstatus/address.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 from pathlib import Path
-from typing import NamedTuple, Optional, TYPE_CHECKING, Tuple, Union
+from typing import NamedTuple, Optional, TYPE_CHECKING, Union
 from urllib.parse import urlparse
 
 import dns.resolver
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 __all__ = ("Address", "minecraft_srv_address_lookup", "async_minecraft_srv_address_lookup")
 
 
-def _valid_urlparse(address: str) -> Tuple[str, Optional[int]]:
+def _valid_urlparse(address: str) -> tuple[str, Optional[int]]:
     """Parses a string address like 127.0.0.1:25565 into host and port parts
 
     If the address doesn't have a specified port, None will be returned instead.
@@ -70,7 +70,7 @@ class Address(_AddressBase):
             raise ValueError(f"Port must be within the allowed range (0-2^16), got {port!r}")
 
     @classmethod
-    def from_tuple(cls, tup: Tuple[str, int]) -> Self:
+    def from_tuple(cls, tup: tuple[str, int]) -> Self:
         """Construct the class from a regular tuple of (host, port), commonly used for addresses."""
         return cls(host=tup[0], port=tup[1])
 

--- a/mcstatus/dns.py
+++ b/mcstatus/dns.py
@@ -1,4 +1,6 @@
-from typing import Optional, Tuple
+from __future__ import annotations
+
+from typing import Optional
 
 import dns.asyncresolver
 import dns.resolver
@@ -35,7 +37,7 @@ async def async_resolve_a_record(hostname: str, lifetime: Optional[float] = None
     return ip
 
 
-def resolve_srv_record(query_name: str, lifetime: Optional[float] = None) -> Tuple[str, int]:
+def resolve_srv_record(query_name: str, lifetime: Optional[float] = None) -> tuple[str, int]:
     """Perform a DNS resolution for SRV record pointing to the Java Server.
 
     :param str address: The address to resolve for.
@@ -53,7 +55,7 @@ def resolve_srv_record(query_name: str, lifetime: Optional[float] = None) -> Tup
     return host, port
 
 
-async def async_resolve_srv_record(query_name: str, lifetime: Optional[float] = None) -> Tuple[str, int]:
+async def async_resolve_srv_record(query_name: str, lifetime: Optional[float] = None) -> tuple[str, int]:
     """Asynchronous alternative to resolve_srv_record.
 
     For more details, check the docstring of resolve_srv_record function.
@@ -67,7 +69,7 @@ async def async_resolve_srv_record(query_name: str, lifetime: Optional[float] = 
     return host, port
 
 
-def resolve_mc_srv(hostname: str, lifetime: Optional[float] = None) -> Tuple[str, int]:
+def resolve_mc_srv(hostname: str, lifetime: Optional[float] = None) -> tuple[str, int]:
     """Resolve SRV record for a minecraft server on given hostname.
 
     :param str address: The address, without port, on which an SRV record is present.
@@ -82,7 +84,7 @@ def resolve_mc_srv(hostname: str, lifetime: Optional[float] = None) -> Tuple[str
     return resolve_srv_record("_minecraft._tcp." + hostname, lifetime=lifetime)
 
 
-async def async_resolve_mc_srv(hostname: str, lifetime: Optional[float] = None) -> Tuple[str, int]:
+async def async_resolve_mc_srv(hostname: str, lifetime: Optional[float] = None) -> tuple[str, int]:
     """Asynchronous alternative to resolve_mc_srv.
 
     For more details, check the docstring of resolve_mc_srv function.

--- a/mcstatus/pinger.py
+++ b/mcstatus/pinger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import json
 import random
-from typing import List, Optional, Union, cast
+from typing import Optional, Union, cast
 
 from mcstatus.address import Address
 from mcstatus.protocol.connection import Connection, TCPAsyncSocketConnection, TCPSocketConnection
@@ -175,7 +175,7 @@ class PingResponse:
 
         online: int
         max: int
-        sample: Optional[List["PingResponse.Players.Player"]]
+        sample: Optional[list["PingResponse.Players.Player"]]
 
         def __init__(self, raw: dict[str, object]):
             if not isinstance(raw, dict):

--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -4,12 +4,13 @@ import asyncio
 import socket
 import struct
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from ctypes import c_int32 as signed_int32
 from ctypes import c_int64 as signed_int64
 from ctypes import c_uint32 as unsigned_int32
 from ctypes import c_uint64 as unsigned_int64
 from ipaddress import ip_address
-from typing import Iterable, Optional, TYPE_CHECKING, Union
+from typing import Optional, TYPE_CHECKING, Union
 
 import asyncio_dgram
 

--- a/mcstatus/querier.py
+++ b/mcstatus/querier.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 import re
 import struct
-from typing import Dict, List, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union
 
 from mcstatus.protocol.connection import Connection, UDPAsyncSocketConnection, UDPSocketConnection
 
@@ -94,10 +94,10 @@ class QueryResponse:
     class Players:
         online: int
         max: int
-        names: List[str]
+        names: list[str]
 
         # TODO: It's a bit weird that we accept str for number parameters, just to convert them in init
-        def __init__(self, online: Union[str, int], max: Union[str, int], names: List[str]):
+        def __init__(self, online: Union[str, int], max: Union[str, int], names: list[str]):
             self.online = int(online)
             self.max = int(max)
             self.names = names
@@ -105,7 +105,7 @@ class QueryResponse:
     class Software:
         version: str
         brand: str
-        plugins: List[str]
+        plugins: list[str]
 
         def __init__(self, version: str, plugins: str):
             self.version = version
@@ -124,7 +124,7 @@ class QueryResponse:
     players: Players
     software: Software
 
-    def __init__(self, raw: Dict[str, str], players: List[str]):
+    def __init__(self, raw: dict[str, str], players: list[str]):
         try:
             self.raw = raw
             self.motd = raw["hostname"]

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -168,7 +168,7 @@ def deprecated(
 
         # If we're deprecating class, deprecate it's methods and return the class
         if inspect.isclass(obj):
-            obj = cast(type[T], obj)
+            obj = cast("type[T]", obj)
 
             if methods is None:
                 raise ValueError("When deprecating a class, you need to specify 'methods' which will get the notice")
@@ -180,7 +180,7 @@ def deprecated(
             return obj
 
         # Regular function deprecation
-        obj = cast(Callable[P, R], obj)
+        obj = cast("Callable[P, R]", obj)
         if methods is not None:
             raise ValueError("Methods can only be specified when decorating a class, not a function")
         return decorate_func(obj, warn_message)

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import inspect
 import warnings
+from collections.abc import Callable, Iterable
 from functools import wraps
-from typing import Callable, Iterable, Optional, TYPE_CHECKING, Tuple, Type, TypeVar, Union, cast, overload
+from typing import Optional, TYPE_CHECKING, TypeVar, Union, cast, overload
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec, Protocol
@@ -20,7 +21,7 @@ R = TypeVar("R")
 R2 = TypeVar("R2")
 
 
-def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> Callable[[Callable[P, R]], Callable[P, R]]:
+def retry(tries: int, exceptions: tuple[type[BaseException]] = (Exception,)) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     Decorator that re-runs given function tries times if error occurs.
 
@@ -75,7 +76,7 @@ def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> 
 
 class DeprecatedReturn(Protocol):
     @overload
-    def __call__(self, __x: Type[T]) -> Type[T]:
+    def __call__(self, __x: type[T]) -> type[T]:
         ...
 
     @overload
@@ -97,14 +98,14 @@ def deprecated(
 
 @overload
 def deprecated(
-    obj: Type[T],
+    obj: type[T],
     *,
     replacement: Optional[str] = None,
     version: Optional[str] = None,
     date: Optional[str] = None,
     msg: Optional[str] = None,
     methods: Iterable[str],
-) -> Type[T]:
+) -> type[T]:
     ...
 
 
@@ -122,7 +123,7 @@ def deprecated(
 
 
 def deprecated(
-    obj: Optional[Union[Callable, Type[object]]] = None,
+    obj: Optional[Union[Callable, type[object]]] = None,
     *,
     replacement: Optional[str] = None,
     version: Optional[str] = None,
@@ -146,10 +147,10 @@ def deprecated(
         ...
 
     @overload
-    def decorate(obj: Type[T]) -> Type[T]:
+    def decorate(obj: type[T]) -> type[T]:
         ...
 
-    def decorate(obj: Union[Callable[P, R], Type[T]]) -> Union[Callable[P, R], Type[T]]:
+    def decorate(obj: Union[Callable[P, R], type[T]]) -> Union[Callable[P, R], type[T]]:
         # Construct and send the warning message
         name = getattr(obj, "__qualname__", obj.__name__)
         warn_message = f"'{name}' is deprecated and is expected to be removed"
@@ -167,7 +168,7 @@ def deprecated(
 
         # If we're deprecating class, deprecate it's methods and return the class
         if inspect.isclass(obj):
-            obj = cast(Type[T], obj)
+            obj = cast(type[T], obj)
 
             if methods is None:
                 raise ValueError("When deprecating a class, you need to specify 'methods' which will get the notice")

--- a/poetry.lock
+++ b/poetry.lock
@@ -49,10 +49,10 @@ typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implem
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-uvloop = ["uvloop (>=0.15.2)"]
-jupyter = ["tokenize-rt (>=3.2.0)", "ipython (>=7.8.0)"]
-d = ["aiohttp (>=3.7.4)"]
 colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bleach"
@@ -134,7 +134,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-test = ["hypothesis (==3.55.3)", "flake8 (==3.7.8)"]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "coverage"
@@ -256,6 +256,17 @@ flake8 = ">=3.0.0"
 dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit"]
 
 [[package]]
+name = "flake8-future-annotations"
+version = "0.0.5"
+description = "Verifies python 3.7+ files use from __future__ import annotations"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+flake8 = "*"
+
+[[package]]
 name = "flake8-isort"
 version = "4.2.0"
 description = "flake8 plugin that integrates isort ."
@@ -269,6 +280,14 @@ isort = ">=4.3.5,<6"
 
 [package.extras]
 test = ["pytest-cov"]
+
+[[package]]
+name = "flake8-pep585"
+version = "0.1.5.1"
+description = "flake8 plugin to enforce new-style type hints (PEP 585)"
+category = "dev"
+optional = false
+python-versions = ">=3.9,<4.0"
 
 [[package]]
 name = "flake8-tidy-imports"
@@ -314,8 +333,8 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["importlib-resources (>=1.3)", "pytest-mypy", "pytest-black (>=0.3.7)", "flufl.flake8", "pyfakefs", "pep517", "packaging", "pytest-enabler (>=1.0.1)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=4.6)"]
+docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=8.2)", "sphinx"]
 
 [[package]]
 name = "iniconfig"
@@ -334,10 +353,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-plugins = ["setuptools"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-requirements_deprecated_finder = ["pip-api", "pipreqs"]
-pipfile_deprecated_finder = ["requirementslib", "pipreqs"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "jeepney"
@@ -458,8 +477,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
@@ -527,7 +546,7 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pyright"
@@ -595,7 +614,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pywin32-ctypes"
@@ -644,8 +663,8 @@ idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+socks = ["win-inet-pton", "PySocks (>=1.5.6,!=1.5.7)"]
 
 [[package]]
 name = "requests-toolbelt"
@@ -741,8 +760,8 @@ toml = ">=0.9.4"
 virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
 
 [package.extras]
-docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
-testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "psutil (>=5.6.1)", "pathlib2 (>=2.3.3)"]
+testing = ["pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest-randomly (>=1.0.0)", "pytest-mock (>=1.10.0)", "pytest-cov (>=2.5.1)", "pytest (>=4.0.0)", "freezegun (>=0.3.11)", "flaky (>=3.4.0)"]
+docs = ["towncrier (>=18.5.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "sphinx (>=2.0.0)", "pygments-github-lexers (>=0.0.5)"]
 
 [[package]]
 name = "tox-poetry"
@@ -850,7 +869,7 @@ docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=8.2)", "sphinx"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4"
-content-hash = "32bdac810e47ea3cc672a4eb40c7d07831ee6298e72d6df83e58355dab234d7f"
+content-hash = "ab1280325f14b17c124f5e7879d87becae28973a3e0a5d9f84a51e0a21bb0df2"
 
 [metadata.files]
 asyncio-dgram = [
@@ -894,10 +913,7 @@ bleach = [
     {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},
     {file = "bleach-4.1.0.tar.gz", hash = "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da"},
 ]
-certifi = [
-    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
-    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
-]
+certifi = []
 cffi = [
     {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
     {file = "cffi-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0"},
@@ -1039,10 +1055,7 @@ distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
-dnspython = [
-    {file = "dnspython-2.2.1-py3-none-any.whl", hash = "sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f"},
-    {file = "dnspython-2.2.1.tar.gz", hash = "sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e"},
-]
+dnspython = []
 docutils = [
     {file = "docutils-0.18.1-py2.py3-none-any.whl", hash = "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c"},
     {file = "docutils-0.18.1.tar.gz", hash = "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"},
@@ -1063,9 +1076,17 @@ flake8-bugbear = [
     {file = "flake8-bugbear-22.7.1.tar.gz", hash = "sha256:e450976a07e4f9d6c043d4f72b17ec1baf717fe37f7997009c8ae58064f88305"},
     {file = "flake8_bugbear-22.7.1-py3-none-any.whl", hash = "sha256:db5d7a831ef4412a224b26c708967ff816818cabae415e76b8c58df156c4b8e5"},
 ]
+flake8-future-annotations = [
+    {file = "flake8-future-annotations-0.0.5.tar.gz", hash = "sha256:da84011070c0d0f623a9c12bd738bea58bc65a3bf5eec20637020069310f8d84"},
+    {file = "flake8_future_annotations-0.0.5-py3-none-any.whl", hash = "sha256:28fc9ae9e5ece5c211b810d856d984f33c0290933f24ae570731a0751c4917c6"},
+]
 flake8-isort = [
     {file = "flake8-isort-4.2.0.tar.gz", hash = "sha256:26571500cd54976bbc0cf1006ffbcd1a68dd102f816b7a1051b219616ba9fee0"},
     {file = "flake8_isort-4.2.0-py3-none-any.whl", hash = "sha256:5b87630fb3719bf4c1833fd11e0d9534f43efdeba524863e15d8f14a7ef6adbf"},
+]
+flake8-pep585 = [
+    {file = "flake8-pep585-0.1.5.1.tar.gz", hash = "sha256:07e6fef6e7b02d5c2b363a6c7008b7aad0db1489c57b4c2629d4b04ed295cec8"},
+    {file = "flake8_pep585-0.1.5.1-py3-none-any.whl", hash = "sha256:80eaa848b45ff7d2d1952782f28cea20d7e0f27c0f57e6a112ee9c4fdd83e6a3"},
 ]
 flake8-tidy-imports = [
     {file = "flake8-tidy-imports-4.8.0.tar.gz", hash = "sha256:df44f9c841b5dfb3a7a1f0da8546b319d772c2a816a1afefcce43e167a593d83"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ flake8-annotations = "^2.9.0"
 flake8-bugbear = "^22.7.1"
 flake8-isort = "^4.2.0"
 flake8-tidy-imports = "^4.8.0"
+flake8-pep585 = {version = "^0.1.5", python = ">=3.9"}
+flake8-future-annotations = "^0.0.5"
 isort = "^5.10.1"
 pep8-naming = "^0.13.1"
 pre-commit = "^2.20.0"

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import ipaddress
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Awaitable, Callable, TypeVar
+from typing import TypeVar
 from unittest.mock import MagicMock, Mock, patch
 
 import dns.resolver


### PR DESCRIPTION
This PR makes our codebase compliant with [PEP-585](https://peps.python.org/pep-0585/). This PEP made commonly used base classes (such as those in `collections.abc`) or the built-in classes (`list`, `dict`, `tuple`, ...) generic. This means usage of generic alternatives in the `typing` module is no longer recommended, and is in fact deprecated.

Since this PEP only applies to python 3.9+, we can't use these generics on runtime, because our project is 3.7+, however with \_\_future\_\_.annotations compiler setting, runtime errors won't be produced, and type-checkers can already understand this new syntax.

To enforce these changes, `flake8-585` (for 3.9+) was added as a dev dependency, and to ensure that when using these changes, we stay 3.7 compatible, this also adds `flake8-future-annotations`, which will produce a flake8 error when trying to use these generics without the \_\_future\_\_.annotations import.
