### PR TITLE
Move async methods to its own classes

### DIFF
--- a/mcstatus/__init__.py
+++ b/mcstatus/__init__.py
@@ -1,6 +1,8 @@
-from mcstatus.server import BedrockServer, JavaServer  # noqa: F401
+from mcstatus.server import AsyncBedrockServer, AsyncJavaServer, BedrockServer, JavaServer  # noqa: F401
 
 __all__ = [
     "BedrockServer",
     "JavaServer",
+    "AsyncJavaServer",
+    "AsyncBedrockServer",
 ]


### PR DESCRIPTION
End date for deprecations was set to 2023-02, six months after opening this PR. I will move it, if this PR will lay too long.