### PR TITLE
Show black diff on failures

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -77,7 +77,7 @@ jobs:
         run: export PIP_USER=0; SKIP=black,isort,flake8,pyright pre-commit run --all-files
 
       - name: Run black formatter check
-        run: black --check .
+        run: black --check --diff .
 
       - name: Run isort import formatter check
         run: isort --check .


### PR DESCRIPTION
Have black show diff on validation workflow failures so it's clear what went wrong directly from the workflow, without needing to run it manually.