### PR TITLE
Fix script name in CLI

### DIFF
--- a/mcstatus/__main__.py
+++ b/mcstatus/__main__.py
@@ -72,11 +72,12 @@ def query(server: JavaServer) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
+        "mcstatus",
         description="""
         mcstatus provides an easy way to query Minecraft servers for
         any information they can expose. It provides three modes of
         access: query, status, ping and json.
-        """
+        """,
     )
 
     parser.add_argument("address", help="The address of the server.")


### PR DESCRIPTION
```
$ python -m mcstatus
usage: __main__.py [-h] address {ping,status,query,json} ...
__main__.py: error: the following arguments are required: address
```