### PR TITLE
Use `|` instead of `typing.Union`, `typing.Optional` (PEP 604)

### DIFF
--- a/mcstatus/address.py
+++ b/mcstatus/address.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 from pathlib import Path
-from typing import NamedTuple, Optional, TYPE_CHECKING, Union
+from typing import NamedTuple, TYPE_CHECKING
 from urllib.parse import urlparse
 
 import dns.resolver
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 __all__ = ("Address", "minecraft_srv_address_lookup", "async_minecraft_srv_address_lookup")
 
 
-def _valid_urlparse(address: str) -> tuple[str, Optional[int]]:
+def _valid_urlparse(address: str) -> tuple[str, int | None]:
     """Parses a string address like 127.0.0.1:25565 into host and port parts
 
     If the address doesn't have a specified port, None will be returned instead.
@@ -55,7 +55,7 @@ class Address(_AddressBase):
     def __init__(self, *a, **kw):
         # We don't call super's __init__, because NamedTuples handle everything
         # from __new__ and the passed self already has all of the parameters set.
-        self._cached_ip: Optional[Union[ipaddress.IPv4Address, ipaddress.IPv6Address]] = None
+        self._cached_ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None = None
 
         # Make sure the address is valid
         self._ensure_validity(self.host, self.port)
@@ -75,7 +75,7 @@ class Address(_AddressBase):
         return cls(host=tup[0], port=tup[1])
 
     @classmethod
-    def from_path(cls, path: Path, *, default_port: Optional[int] = None) -> Self:
+    def from_path(cls, path: Path, *, default_port: int | None = None) -> Self:
         """Construct the class from a Path object.
 
         If path has a port specified, use it, if not fall back to default_port.
@@ -85,7 +85,7 @@ class Address(_AddressBase):
         return cls.parse_address(address, default_port=default_port)
 
     @classmethod
-    def parse_address(cls, address: str, *, default_port: Optional[int] = None) -> Self:
+    def parse_address(cls, address: str, *, default_port: int | None = None) -> Self:
         """Parses a string address like 127.0.0.1:25565 into host and port parts
 
         If the address has a port specified, use it, if not, fall back to default_port.
@@ -104,7 +104,7 @@ class Address(_AddressBase):
                 )
         return cls(host=hostname, port=port)
 
-    def resolve_ip(self, lifetime: Optional[float] = None) -> Union[ipaddress.IPv4Address, ipaddress.IPv6Address]:
+    def resolve_ip(self, lifetime: float | None = None) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
         """Resolves a hostname's A record into an IP address.
 
         If the host is already an IP, this resolving is skipped
@@ -132,7 +132,7 @@ class Address(_AddressBase):
         self._cached_ip = ip
         return self._cached_ip
 
-    async def async_resolve_ip(self, lifetime: Optional[float] = None) -> Union[ipaddress.IPv4Address, ipaddress.IPv6Address]:
+    async def async_resolve_ip(self, lifetime: float | None = None) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
         """Resolves a hostname's A record into an IP address.
 
         See the docstring for `resolve_ip` for further info. This function is purely
@@ -157,8 +157,8 @@ class Address(_AddressBase):
 def minecraft_srv_address_lookup(
     address: str,
     *,
-    default_port: Optional[int] = None,
-    lifetime: Optional[float] = None,
+    default_port: int | None = None,
+    lifetime: float | None = None,
 ) -> Address:
     """Parses the address, if it doesn't include port, tries SRV record, if it's not there, falls back on default_port
 
@@ -202,8 +202,8 @@ def minecraft_srv_address_lookup(
 async def async_minecraft_srv_address_lookup(
     address: str,
     *,
-    default_port: Optional[int] = None,
-    lifetime: Optional[float] = None,
+    default_port: int | None = None,
+    lifetime: float | None = None,
 ) -> Address:
     """Parses the address, if it doesn't include port, tries SRV record, if it's not there, falls back on default_port
 

--- a/mcstatus/bedrock_status.py
+++ b/mcstatus/bedrock_status.py
@@ -4,7 +4,6 @@ import asyncio
 import socket
 import struct
 from time import perf_counter
-from typing import Optional
 
 import asyncio_dgram
 
@@ -89,8 +88,8 @@ class BedrockStatusResponse:
         players_online: int,
         players_max: int,
         motd: str,
-        map_: Optional[str],
-        gamemode: Optional[str],
+        map_: str | None,
+        gamemode: str | None,
     ):
         self.version = self.Version(protocol, brand, version)
         self.latency = latency

--- a/mcstatus/dns.py
+++ b/mcstatus/dns.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import Optional
-
 import dns.asyncresolver
 import dns.resolver
 from dns.rdatatype import RdataType
 
 
-def resolve_a_record(hostname: str, lifetime: Optional[float] = None) -> str:
+def resolve_a_record(hostname: str, lifetime: float | None = None) -> str:
     """Perform a DNS resolution for an A record to given hostname
 
     :param str hostname: The address to resolve for.
@@ -24,7 +22,7 @@ def resolve_a_record(hostname: str, lifetime: Optional[float] = None) -> str:
     return ip
 
 
-async def async_resolve_a_record(hostname: str, lifetime: Optional[float] = None) -> str:
+async def async_resolve_a_record(hostname: str, lifetime: float | None = None) -> str:
     """Asynchronous alternative to resolve_a_record.
 
     For more details, check the docstring of resolve_a_record function.
@@ -37,7 +35,7 @@ async def async_resolve_a_record(hostname: str, lifetime: Optional[float] = None
     return ip
 
 
-def resolve_srv_record(query_name: str, lifetime: Optional[float] = None) -> tuple[str, int]:
+def resolve_srv_record(query_name: str, lifetime: float | None = None) -> tuple[str, int]:
     """Perform a DNS resolution for SRV record pointing to the Java Server.
 
     :param str address: The address to resolve for.
@@ -55,7 +53,7 @@ def resolve_srv_record(query_name: str, lifetime: Optional[float] = None) -> tup
     return host, port
 
 
-async def async_resolve_srv_record(query_name: str, lifetime: Optional[float] = None) -> tuple[str, int]:
+async def async_resolve_srv_record(query_name: str, lifetime: float | None = None) -> tuple[str, int]:
     """Asynchronous alternative to resolve_srv_record.
 
     For more details, check the docstring of resolve_srv_record function.
@@ -69,7 +67,7 @@ async def async_resolve_srv_record(query_name: str, lifetime: Optional[float] = 
     return host, port
 
 
-def resolve_mc_srv(hostname: str, lifetime: Optional[float] = None) -> tuple[str, int]:
+def resolve_mc_srv(hostname: str, lifetime: float | None = None) -> tuple[str, int]:
     """Resolve SRV record for a minecraft server on given hostname.
 
     :param str address: The address, without port, on which an SRV record is present.
@@ -84,7 +82,7 @@ def resolve_mc_srv(hostname: str, lifetime: Optional[float] = None) -> tuple[str
     return resolve_srv_record("_minecraft._tcp." + hostname, lifetime=lifetime)
 
 
-async def async_resolve_mc_srv(hostname: str, lifetime: Optional[float] = None) -> tuple[str, int]:
+async def async_resolve_mc_srv(hostname: str, lifetime: float | None = None) -> tuple[str, int]:
     """Asynchronous alternative to resolve_mc_srv.
 
     For more details, check the docstring of resolve_mc_srv function.

--- a/mcstatus/pinger.py
+++ b/mcstatus/pinger.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import json
 import random
-from typing import Optional, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from mcstatus.address import Address
 from mcstatus.protocol.connection import Connection, TCPAsyncSocketConnection, TCPSocketConnection
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
         underlined: bool
         obfuscated: bool
 
-    RawResponseDescription: TypeAlias = Union[RawResponseDescriptionWhenDict, list[RawResponseDescriptionWhenDict], str]
+    RawResponseDescription: TypeAlias = "RawResponseDescriptionWhenDict | list[RawResponseDescriptionWhenDict] | str"
 
     class RawResponse(TypedDict):
         description: RawResponseDescription
@@ -85,7 +85,7 @@ class ServerPinger:
         connection: TCPSocketConnection,
         address: Address,
         version: int = 47,
-        ping_token: Optional[int] = None,
+        ping_token: int | None = None,
     ):
         if ping_token is None:
             ping_token = random.randint(0, (1 << 63) - 1)
@@ -148,7 +148,7 @@ class AsyncServerPinger(ServerPinger):
         connection: TCPAsyncSocketConnection,
         address: Address,
         version: int = 47,
-        ping_token: Optional[int] = None,
+        ping_token: int | None = None,
     ):
         # We do this to inform python about self.connection type (it's async)
         super().__init__(connection, address=address, version=version, ping_token=ping_token)  # type: ignore[arg-type]
@@ -218,7 +218,7 @@ class PingResponse:
 
         online: int
         max: int
-        sample: Optional[list["PingResponse.Players.Player"]]
+        sample: list["PingResponse.Players.Player"] | None
 
         def __init__(self, raw: RawResponsePlayers):
             if not isinstance(raw, dict):
@@ -266,7 +266,7 @@ class PingResponse:
     players: Players
     version: Version
     description: str
-    favicon: Optional[str]
+    favicon: str | None
     latency: float = 0
 
     def __init__(self, raw: RawResponse):

--- a/mcstatus/querier.py
+++ b/mcstatus/querier.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 import re
 import struct
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from mcstatus.protocol.connection import Connection, UDPAsyncSocketConnection, UDPSocketConnection
 
@@ -97,7 +97,7 @@ class QueryResponse:
         names: list[str]
 
         # TODO: It's a bit weird that we accept str for number parameters, just to convert them in init
-        def __init__(self, online: Union[str, int], max: Union[str, int], names: list[str]):
+        def __init__(self, online: str | int, max: str | int, names: list[str]):
             self.online = int(online)
             self.max = int(max)
             self.names = names

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import dns.resolver
 
@@ -38,7 +38,7 @@ class MCServer(ABC):
 
     DEFAULT_PORT: int
 
-    def __init__(self, host: str, port: Optional[int] = None, timeout: float = 3):
+    def __init__(self, host: str, port: int | None = None, timeout: float = 3):
         if port is None:
             port = self.DEFAULT_PORT
         self.address = Address(host, port)

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -5,7 +5,7 @@ import inspect
 import warnings
 from collections.abc import Callable, Iterable
 from functools import wraps
-from typing import Any, Optional, TYPE_CHECKING, TypeVar, Union, cast, overload
+from typing import Any, TYPE_CHECKING, TypeVar, cast, overload
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec, Protocol
@@ -88,10 +88,10 @@ class DeprecatedReturn(Protocol):
 def deprecated(
     obj: Callable[P, R],
     *,
-    replacement: Optional[str] = None,
-    version: Optional[str] = None,
-    date: Optional[str] = None,
-    msg: Optional[str] = None,
+    replacement: str | None = None,
+    version: str | None = None,
+    date: str | None = None,
+    msg: str | None = None,
 ) -> Callable[P, R]:
     ...
 
@@ -100,10 +100,10 @@ def deprecated(
 def deprecated(
     obj: type[T],
     *,
-    replacement: Optional[str] = None,
-    version: Optional[str] = None,
-    date: Optional[str] = None,
-    msg: Optional[str] = None,
+    replacement: str | None = None,
+    version: str | None = None,
+    date: str | None = None,
+    msg: str | None = None,
     methods: Iterable[str],
 ) -> type[T]:
     ...
@@ -113,11 +113,11 @@ def deprecated(
 def deprecated(
     obj: None = None,
     *,
-    replacement: Optional[str] = None,
-    version: Optional[str] = None,
-    date: Optional[str] = None,
-    msg: Optional[str] = None,
-    methods: Optional[Iterable[str]] = None,
+    replacement: str | None = None,
+    version: str | None = None,
+    date: str | None = None,
+    msg: str | None = None,
+    methods: Iterable[str] | None = None,
 ) -> DeprecatedReturn:
     ...
 
@@ -125,12 +125,12 @@ def deprecated(
 def deprecated(
     obj: Any = None,  # noqa: ANN401
     *,
-    replacement: Optional[str] = None,
-    version: Optional[str] = None,
-    date: Optional[str] = None,
-    msg: Optional[str] = None,
-    methods: Optional[Iterable[str]] = None,
-) -> Union[Callable, type[object]]:
+    replacement: str | None = None,
+    version: str | None = None,
+    date: str | None = None,
+    msg: str | None = None,
+    methods: Iterable[str] | None = None,
+) -> Callable | type[object]:
     if date is not None and version is not None:
         raise ValueError("Expected removal timeframe can either be a date, or a version, not both.")
 
@@ -150,7 +150,7 @@ def deprecated(
     def decorate(obj: type[T]) -> type[T]:
         ...
 
-    def decorate(obj: Union[Callable[P, R], type[T]]) -> Union[Callable[P, R], type[T]]:
+    def decorate(obj: Callable[P, R] | type[T]) -> Callable[P, R] | type[T]:
         # Construct and send the warning message
         name = getattr(obj, "__qualname__", obj.__name__)
         warn_message = f"'{name}' is deprecated and is expected to be removed"

--- a/poetry.lock
+++ b/poetry.lock
@@ -263,6 +263,18 @@ flake8 = "*"
 setuptools = "*"
 
 [[package]]
+name = "flake8-new-union-types"
+version = "0.4.1"
+description = "Flake8 plugin to enforce the new Union and Optional annotation syntax defined in PEP 604"
+category = "dev"
+optional = false
+python-versions = ">=3.8,<4.0"
+
+[package.dependencies]
+attrs = ">=21.4.0"
+flake8 = ">=3.0.0"
+
+[[package]]
 name = "flake8-pep585"
 version = "0.1.5.1"
 description = "flake8 plugin to enforce new-style type hints (PEP 585)"
@@ -867,7 +879,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4"
-content-hash = "851c489550df108814e850128e939d363cbc4dd0b6ac858779a616cfd70f2e77"
+content-hash = "403ad3b42e5d9b70f41b64de74b5e04178129658d2924056a7a0ef3c872e1977"
 
 [metadata.files]
 asyncio-dgram = [
@@ -1104,6 +1116,10 @@ flake8-bugbear = [
 flake8-future-annotations = [
     {file = "flake8-future-annotations-0.0.5.tar.gz", hash = "sha256:da84011070c0d0f623a9c12bd738bea58bc65a3bf5eec20637020069310f8d84"},
     {file = "flake8_future_annotations-0.0.5-py3-none-any.whl", hash = "sha256:28fc9ae9e5ece5c211b810d856d984f33c0290933f24ae570731a0751c4917c6"},
+]
+flake8-new-union-types = [
+    {file = "flake8-new-union-types-0.4.1.tar.gz", hash = "sha256:0a9dd421099f2525f8be525977ff6632b13b68719a7b0807cf49028d4287b0aa"},
+    {file = "flake8_new_union_types-0.4.1-py3-none-any.whl", hash = "sha256:92737a2f598772d5aedd05b5450c5dd200e0f1acd42b3c1f95dbbe3211af2009"},
 ]
 flake8-pep585 = [
     {file = "flake8-pep585-0.1.5.1.tar.gz", hash = "sha256:07e6fef6e7b02d5c2b363a6c7008b7aad0db1489c57b4c2629d4b04ed295cec8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ flake8-annotations = "^2.9.1"
 flake8-bugbear = "^22.9.23"
 flake8-tidy-imports = "^4.8.0"
 flake8-pep585 = {version = "^0.1.5", python = ">=3.9"}
+flake8-new-union-types = {version = "^0.4.1", python = ">=3.8"}
 flake8-future-annotations = "^0.0.5"
 isort = "^5.10.1"
 pep8-naming = "^0.13.2"


### PR DESCRIPTION
Why am I using `flake8-new-union-types`, and not `flake8-pep604`? Second one is checking only imports and only `typing.Union`, `typing.Optional` was ignored.

(Inspired by #375. There are also description why this will work on 3.7, even if was added only in 3,10)