### PR TITLE
CRITICAL: Add a temporary fix to fix workflows

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -62,7 +62,10 @@ jobs:
       - name: Install dependencies using poetry
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
-          pip install poetry
+          # NOTE: installing poetry 1.1.15 explicitly is a temporary fix
+          # for https://github.com/py-mine/mcstatus/runs/8120416778?check_suite_focus=true#step:6:152,
+          # It seems like poetry 1.2.0 has changed some core logic causing pip to fail installation
+          pip install poetry==1.1.15
           pip install tox
           pip install tox-poetry
           pip install tox-gh-actions

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -57,7 +57,10 @@ jobs:
       - name: Install dependencies using poetry
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
-          pip install poetry
+          # NOTE: installing poetry 1.1.15 explicitly is a temporary fix
+          # for https://github.com/py-mine/mcstatus/runs/8120416778?check_suite_focus=true#step:6:152,
+          # It seems like poetry 1.2.0 has changed some core logic causing pip to fail installation
+          pip install poetry==1.1.15
           poetry install
 
       # Cache pre-commit environment


### PR DESCRIPTION
Poetry 1.2.0 has been released recently, and it seems like a change in it's behavior is currently preventing both the validation and the unit-test workflow from running completely, as they were installing the most recent version, rather than an exact specific version.

This temporary fix simply explicitly installs poetry 1.1.15 instead of the most recent (1.2.0), where this issue doesn't occur. However a full fix should address this issue and work with the updated 1.2.0 version.

**NOTE:** This is a critical PR and it should be merged as quickly as possible, as it blocks all other PRs considering these workflows will be failing on them.