### PR TITLE
Fix poetry 1.2 support

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -11,19 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Make sure pip caches dependencies and installs as user
-  PIP_NO_CACHE_DIR: false
-  PIP_USER: 1
-
-  # Make sure poetry won't use virtual environments
-  POETRY_VIRTUALENVS_CREATE: false
-
-  # Specify paths here, so we know exactly where things are for caching
-  PYTHONUSERBASE: ${{ github.workspace }}/.cache/py-user-base
-  POETRY_CACHE_DIR: ${{ github.workspace }}/.cache/py-user-base
-  TOXDIR: ${{ github.workspace }}/.tox
-
 jobs:
   tox-test:
     runs-on: ${{ matrix.platform }}
@@ -37,41 +24,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Python setup
-        id: python
-        uses: actions/setup-python@v2
+      - name: Install Python Dependencies
+        uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.1
+        id: setup_python
         with:
-          python-version: ${{ matrix.python-version }}
-
-      # Cache python dependencies so that unless we change them,
-      # we won't need to reinstall them with each workflow run.
-      # The key is a composite of multiple values, which when changed
-      # the cache won't be restored in order to make updating possible
-      - name: Python dependency caching
-        uses: actions/cache@v2
-        id: python_cache
-        with:
-          path: |
-            ${{ env.PYTHONUSERBASE }}
-            ${{ env.TOXDIR }}
-          key: "python-1-${{ runner.os }}-${{ env.PYTHONUSERBASE }}-\
-                ${{ env.TOXDIR }}-${{ steps.python.outputs.python-version }}-\
-                ${{ hashFiles('./pyproject.toml', './poetry.lock') }}"
+          dev: false
+          python_version: "${{ matrix.python-version }}"
 
       # In case the dependencies weren't restored, install them
-      - name: Install dependencies using poetry
-        if: steps.python_cache.outputs.cache-hit != 'true'
-        run: |
-          # NOTE: installing poetry 1.1.15 explicitly is a temporary fix
-          # for https://github.com/py-mine/mcstatus/runs/8120416778?check_suite_focus=true#step:6:152,
-          # It seems like poetry 1.2.0 has changed some core logic causing pip to fail installation
-          pip install poetry==1.1.15
-          pip install tox
-          pip install tox-poetry
-          pip install tox-gh-actions
+      - name: Install tox dependencies
+        if: steps.setup_python.outputs.cache-hit != 'true'
+        run: poetry run pip install tox tox-poetry tox-gh-actions
 
       - name: Test with tox
-        run: python -m tox
+        run: poetry run tox
         env:
           PIP_USER: 0  # We want tox to use it's environments, not user installs
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,74 +10,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Make sure pip caches dependencies and installs as user
-  PIP_NO_CACHE_DIR: false
-  PIP_USER: 1
-
-  # Make sure poetry won't use virtual environments
-  POETRY_VIRTUALENVS_CREATE: false
-
-  # Specify paths here, so we know what to cache
-  POETRY_CACHE_DIR: ${{ github.workspace }}/.cache/py-user-base
-  PYTHONUSERBASE: ${{ github.workspace }}/.cache/py-user-base
-  PRE_COMMIT_HOME: ${{ github.workspace }}/.cache/pre-commit-cache
-
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Add custom PYTHONUSERBASE to PATH
-        run: echo '${{ env.PYTHONUSERBASE }}/bin/' >> $GITHUB_PATH
-
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Python setup
-        id: python
-        uses: actions/setup-python@v2
+      - name: Install Python Dependencies
+        uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.1
         with:
-          python-version: '3.9.5'
-
-      # Cache python dependencies so that unless we change them,
-      # we won't need to reinstall them with each workflow run.
-      # The key is a composite of multiple values, which when changed
-      # the cache won't be restored in order to make updating possible
-      - name: Python dependency caching
-        uses: actions/cache@v2
-        id: python_cache
-        with:
-          path: ${{ env.PYTHONUSERBASE }}
-          key: "python-0-${{ runner.os }}-${{ env.PYTHONUSERBASE }}-\
-                ${{ steps.python.outputs.python-version }}-\
-                ${{ hashFiles('./pyproject.toml', './poetry.lock') }}"
-
-      # In case the dependencies weren't restored, install them
-      - name: Install dependencies using poetry
-        if: steps.python_cache.outputs.cache-hit != 'true'
-        run: |
-          # NOTE: installing poetry 1.1.15 explicitly is a temporary fix
-          # for https://github.com/py-mine/mcstatus/runs/8120416778?check_suite_focus=true#step:6:152,
-          # It seems like poetry 1.2.0 has changed some core logic causing pip to fail installation
-          pip install poetry==1.1.15
-          poetry install
-
-      # Cache pre-commit environment
-      # The key is a composite of multiple values, which when changed
-      # the cache won't be restored in order to make updating possible
-      - name: Pre-commit Environment Caching
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.PRE_COMMIT_HOME }}
-          key: "precommit-0-${{ runner.os }}-${{ env.PRE_COMMIT_HOME }}-\
-                ${{ steps.python.outputs.python-version }}-\
-                ${{ hashFiles('./.pre-commit-config.yaml') }}"
-
-      # Run the actual linting steps here:
+          dev: true
+          python_version: "3.10.5"
 
       - name: Run pre-commit hooks
-        run: export PIP_USER=0; SKIP=black,isort,flake8,pyright pre-commit run --all-files
+        run: SKIP=black,isort,flake8,pyright pre-commit run --all-files
 
       - name: Run black formatter check
         run: black --check --diff .
@@ -86,7 +34,7 @@ jobs:
         run: isort --check .
 
       - name: Run pyright type checker
-        run: pyright -v $PYTHONUSERBASE
+        run: pyright .
 
       - name: Run flake8 linter
         run: flake8 .


### PR DESCRIPTION
This replaces the original temporary fix in #391 of locking poetry to an older version with a long-term fix that's compatible with this new version of poetry (1.2).

**Recap of the core issue:**
Release of poetry 1.2, introduced a regression which broke pip --user installs. These types of installs were the main way we performed instalations in the CI workflows, as they made it more convenient to control the location, availability and caching of packages.

Poetry's team does not recognize this as a supported use case, so major changes were required to get everything working again. Most of the changes were consolidated into HassanAbouelela/setup-python which we now use to set up python and poetry for us.

