### PR TITLE
Bump actions/upload-artifact to v3

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Upload a Build Artifact
         if: always() && steps.prepare-artifact.outcome == 'success'
         continue-on-error: true
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pull-request-payload
           path: pull_request_payload.json

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Upload a Build Artifact
         if: always() && steps.prepare-artifact.outcome == 'success'
         continue-on-error: true
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pull-request-payload
           path: pull_request_payload.json


### PR DESCRIPTION
GitHub has recently deprecated the use of Node.js 12 based workflow actions, which affected several commonly used official (and unofficial) actions. In our case, most of the used actions were already up to date, except for `actions/upload-artifact`, where we've been using version 2, instead of the updated version 3.

This PR updates this dependency, getting rid of the below deprecation warning in our action runs:

![image](https://user-images.githubusercontent.com/20902250/195720733-9cd56b23-fb47-45b0-ae6a-0820316134f6.png)
