### PR TITLE
Add 3.11 to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 isolated_build = True
 envlist =
-  format-check,lint,py{38,39,310},coverage
+  format-check,lint,py{38,39,310,311},coverage
 
 [gh-actions]
 python =
     3.8: py38
     3.9: py39
-    3.10: py310, coverage
+    3.10: py310
+    3.11: py311, coverage
 
 [testenv]
 setenv =
@@ -33,7 +34,7 @@ commands =
 
 [testenv:coverage]
 depends =
-  py{38,39,310}
+  py{38,39,310,311}
 setenv =
   COVERAGE_FILE=.coverage
 commands =


### PR DESCRIPTION
#431 was supposed to add 3.11 to tested versions. However it didn't add 3.11 to the list of tox environments.

This causes the 3.11 tests to be entirely skipped, and even though they're passing, it's purely because tox command doesn't end with non-zero code when it's ran with an unsupported environment.

As can be seen below, they do however produce a warning, informing us that this workflow has been entirely skipped, and no tests were ran for 3.11.

![image](https://user-images.githubusercontent.com/20902250/207620513-3724bfc8-2e4a-479e-994c-31f365ff6acb.png)


This PR fixes that and adds 3.11 to the list of tox environments.