### PR TITLE
Don't run tests on intermediate versions

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.11"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Running tests for the oldest and the newest versions should be enough to cover all of the cases, there's no real need to run any tests for the intermediate versions.

This will significantly speed tests up, as it means dropping the amount of workflows ran for each commit by 6 (2 tests for each of the 3 platforms - ubuntu, mac, win).