### PR TITLE
Mark `MCServer` as Public API

### DIFF
--- a/mcstatus/__init__.py
+++ b/mcstatus/__init__.py
@@ -1,6 +1,7 @@
-from mcstatus.server import BedrockServer, JavaServer  # noqa: F401
+from mcstatus.server import BedrockServer, JavaServer, MCServer  # noqa: F401
 
 __all__ = [
-    "BedrockServer",
+    "MCServer",
     "JavaServer",
+    "BedrockServer",
 ]

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
-__all__ = ["JavaServer", "BedrockServer"]
+__all__ = ["MCServer", "JavaServer", "BedrockServer"]
 
 
 class MCServer(ABC):


### PR DESCRIPTION
So users can use it in `isinstance` checks.

I also sorted `__all__` in `__init__.py` to the same order as in `mcstatus/server.py`.