### PR TITLE
Mention Dinnerbone as author

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ def _get_project_meta() -> dict[str, str]:
 pkg_meta = _get_project_meta()
 project = str(pkg_meta["name"])
 copyright = str(date.today().year) + ", py-mine"
-author = "py-mine"
+author = "Dinnerbone"
 
 parsed_version = parse_version(pkg_meta["version"])
 


### PR DESCRIPTION
> I'd like to still give attribution to dinnerbone here. I'll look for a way to add `py-mine` to the list in pyproject.toml and use `pkg_meta["authors"]` here.

_Originally posted by @kevinkjt2000 in https://github.com/py-mine/mcstatus/pull/450#discussion_r1059691298_
      