### PR TITLE
Update all dependencies at once

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       interval: "daily"
     labels:
       - "area: dependencies"
+    open-pull-requests-limit: 9999
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Since https://github.com/dependabot/dependabot-core/issues/5766 was recently fixed, dependabot opens 5 PRs a day to update all dependencies.

This PR will release lock of 5 PRs, and once dependabot will run - I will open another PR with undoing the changes here.