### PR TITLE
Fix bug with ping servers

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -100,6 +100,7 @@ class JavaServer(MCServer):
     def _retry_ping(self, connection: TCPSocketConnection, **kwargs) -> float:
         pinger = ServerPinger(connection, address=self.address, **kwargs)
         pinger.handshake()
+        pinger.read_status()
         return pinger.test_ping()
 
     async def async_ping(self, **kwargs) -> float:
@@ -116,6 +117,7 @@ class JavaServer(MCServer):
     async def _retry_async_ping(self, connection: TCPAsyncSocketConnection, **kwargs) -> float:
         pinger = AsyncServerPinger(connection, address=self.address, **kwargs)
         pinger.handshake()
+        pinger.read_status()
         ping = await pinger.test_ping()
         return ping
 


### PR DESCRIPTION
The library sends ping incorrectly, need to request a ping after receiving the status, and not breaking the connection.

I got this error when pinging the server:
[12:46:27 WARN]: Error whilst handling query packet from /95.217.180.53:52188
io.github.waterfallmc.waterfall.utils.FastException: No Session!