### PR TITLE
Use `increase-if-necessary` strategy for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       interval: "daily"
     labels:
       - "area: dependencies"
+    versioning-strategy: increase-if-necessary
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This will help to avoid such commits as 42d758a and PRs where dependabot bumps version from `^1.2.3` to `>=1.2.3,<1.4`.

See https://github.com/dependabot/dependabot-core/issues/1440.