### PR TITLE
Ignore exceptions on socket close

### DIFF
--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import socket
 import struct
 from abc import ABC, abstractmethod
@@ -498,7 +499,12 @@ class SocketConnection(BaseSyncConnection):
     def close(self) -> None:
         """Close :attr:`.socket`."""
         if self.socket is not None:  # If initialized
-            self.socket.shutdown(socket.SHUT_RDWR)
+            try:
+                self.socket.shutdown(socket.SHUT_RDWR)
+            except OSError as exception:  # Socket wasn't connected (nothing to shut down)
+                if exception.errno != errno.ENOTCONN:
+                    raise
+
             self.socket.close()
 
     def __enter__(self) -> Self:


### PR DESCRIPTION
The #422 overwrote #379 which had the same fix. Although, it was applied to `__del__` method only, and the idea to add this try-except in `close` method was dismissed as we excepted to get this error only during garbage collection (which is not the case since #422).

Fixes #538.