### PR TITLE
Move zeros in the packet to follow documentation update

### DIFF
--- a/mcstatus/bedrock_status.py
+++ b/mcstatus/bedrock_status.py
@@ -17,7 +17,7 @@ __all__ = ("BedrockServerStatus", "BedrockStatusResponse")
 class BedrockServerStatus:
     request_status_data = bytes.fromhex(
         # see https://wiki.vg/Raknet_Protocol#Unconnected_Ping
-        "01" + "000000000000000000" + "ffff00fefefefefdfdfdfd12345678" + "0000000000000000"  # fmt: skip
+        "01" + "0000000000000000" + "00ffff00fefefefefdfdfdfd12345678" + "0000000000000000"  # fmt: skip
     )
 
     def __init__(self, address: Address, timeout: float = 3):


### PR DESCRIPTION
"01" + "000000000000000000" + "ffff00fefefefefdfdfdfd12345678" + "0000000000000000"

According to https://wiki.vg/Raknet_Protocol#Unconnected_Ping, the packet is a byte, (01), followed by 8 bytes for the time. In the code, there are 9 bytes in that part! (two extra zeroes!)
After the time, it should be followed by MAGIC. 

Now, wiki.vg says the following about it:
.  | Size (Bytes) | Range | Notes
-- | -- | -- | --
Magic | 16 | 00ffff00fefefefefdfdfdfd12345678 | Always those hex bytes, corresponding to RakNet's default OFFLINE_MESSAGE_DATA_ID

Oh! There are the first two zeroes missing! I wonder where they went? (spoiler: they are in the part for the time...)

![image](https://github.com/py-mine/mcstatus/assets/43420467/8b9f93fe-a59d-489f-aa6f-7aa923398602)



TL;DR: I moved two zeroes 
