### PR TITLE
Fix server icon saving example

### DIFF
--- a/docs/pages/faq.rst
+++ b/docs/pages/faq.rst
@@ -59,14 +59,19 @@ On Bedrock, only official servers have a server image. There is no way to get
 or set an icon to a custom server. For Java servers, you can use
 :attr:`status.icon <mcstatus.status_response.JavaStatusResponse.icon>`
 attribute. It will return `Base64 <https://en.wikipedia.org/wiki/Base64>`_
-encoded PNG image, so you can decode it in that way:
+encoded PNG image. If you wish to save this image into a file, this is how:
 
 .. code-block:: python
 
+    from mcstatus import JavaServer
     import base64
 
-    with open("server-icon.png", "wb") as server_icon_file:
-        server_favicon_file.write(base64.decodebytes(status.icon))
+    server = JavaServer.lookup("hypixel.net")
+    status = server.status()
+
+    decoded_icon = base64.b64decode(status.icon.removeprefix("data:image/png;base64,"))
+    with open("server-icon.png", "wb") as f:
+        f.write(decoded_icon)
 
 .. note::
     Most modern browsers support simply pasting the raw Base64 image into the

--- a/docs/pages/faq.rst
+++ b/docs/pages/faq.rst
@@ -63,8 +63,8 @@ encoded PNG image. If you wish to save this image into a file, this is how:
 
 .. code-block:: python
 
-    from mcstatus import JavaServer
     import base64
+    from mcstatus import JavaServer
 
     server = JavaServer.lookup("hypixel.net")
     status = server.status()


### PR DESCRIPTION
The original example we had in FAQ doesn't work for multiple reasons:

1. `base64.decodebytes` function expects bytes as the input arg, however `status.icon` is a string, we should be using `base64.b64decode` instead.
2. The base64 data is prefixed with `"data:image/png;base64,"`, which isn't valid base64 data, and should not be a part of the saved PNG, it's just a a prefix informing us what kind of image this is, and what is the formatting (and a fairly standard one, even browsers can interpret it, but it certainly shouldn't be interpreted as part of the base64 encoded image data).
3. There was a typo in the variable holding the file pointer from context manager (`server_icon_file`) and the variable used in body (`server_favicon_file`).

The snippet originally also didn't contain the code that originally obtained this image, I've included that to make it very clear where the `status` variable came from.