### PR TITLE
Fix `translate` field name confusion

### DIFF
--- a/mcstatus/motd/components.py
+++ b/mcstatus/motd/components.py
@@ -114,7 +114,7 @@ class WebColor:
 class TranslationTag:
     """Represents a ``translate`` field in server's answer.
 
-    This just exist, but is completely ignored by our transformers.
+    This just exists, but is completely ignored by our transformers.
     You can find translation tags in :attr:`Motd.parsed <mcstatus.motd.Motd.parsed>` attribute.
 
     .. seealso:: `Minecraft's wiki. <https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Translated_Text>`__

--- a/mcstatus/status_response.py
+++ b/mcstatus/status_response.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
         protocol: int
 
     class RawJavaResponseMotdWhenDict(TypedDict, total=False):
-        text: str  # only present if translation is set
-        translation: str  # same to the above field
+        text: str  # only present if `translate` is set
+        translate: str  # same to the above field
         extra: list[RawJavaResponseMotdWhenDict]
 
         color: str

--- a/tests/motd/test_motd.py
+++ b/tests/motd/test_motd.py
@@ -102,8 +102,8 @@ class TestMotdParse:
             Formatting.RESET,
         ]
 
-    def test_translation_string(self):
-        assert Motd.parse(RawJavaResponseMotdWhenDict(translation="the key")).parsed == [
+    def test_translate_string(self):
+        assert Motd.parse(RawJavaResponseMotdWhenDict(translate="the key")).parsed == [
             TranslationTag("the key"),
             Formatting.RESET,
         ]


### PR DESCRIPTION
I am keeping `TranslationTag` as it is, because it is grammatically correct.