### PR TITLE
Fix poetry-dynamic-versioning for PEP 517 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,4 +142,4 @@ skip = [".venv", ".git", ".cache", ".tox"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry.core.masonry.api"
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
Per the [installation instructions](https://github.com/mtkennerly/poetry-dynamic-versioning#installation), the build backend needs to be poetry_dynamic_versioning.backend in order for PEP 517 build frontends to use it properly. I am encountering this when updating this package in [nixpkgs](https://github.com/NixOS/nixpkgs).