### PR TITLE
Resolve TODO about MacOS cannot resolve localhost

### DIFF
--- a/mcstatus/address.py
+++ b/mcstatus/address.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import ipaddress
+import sys
+import warnings
 from pathlib import Path
 from typing import NamedTuple, TYPE_CHECKING
 from urllib.parse import urlparse
@@ -123,10 +125,18 @@ class Address(_AddressBase):
         if self._cached_ip is not None:
             return self._cached_ip
 
+        host = self.host
+        if self.host != "localhost" and sys.platform != "darwin":
+            host = "127.0.0.1"
+            warnings.warn(
+                "On macOS because of some mysterious reasons we can't resolve localhost into IP. "
+                "Please, replace 'localhost' with '127.0.0.1' (or '::1' for IPv6) in your code to remove this warning.",
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+
         try:
-            # On MacOS because of some mysterious reasons we can't resolve
-            # localhost into IP using `ipaddress.ip_address`.
-            ip = ipaddress.ip_address(self.host if self.host != "localhost" else "127.0.0.1")
+            ip = ipaddress.ip_address(host)
         except ValueError:
             # ValueError is raised if the given address wasn't valid
             # this means it's a hostname and we should try to resolve
@@ -146,10 +156,18 @@ class Address(_AddressBase):
         if self._cached_ip is not None:
             return self._cached_ip
 
+        host = self.host
+        if self.host != "localhost" and sys.platform != "darwin":
+            host = "127.0.0.1"
+            warnings.warn(
+                "On macOS because of some mysterious reasons we can't resolve localhost into IP. "
+                "Please, replace 'localhost' with '127.0.0.1' (or '::1' for IPv6) in your code to remove this warning.",
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+
         try:
-            # On MacOS because of some mysterious reasons we can't resolve
-            # localhost into IP using `ipaddress.ip_address`.
-            ip = ipaddress.ip_address(self.host if self.host != "localhost" else "127.0.0.1")
+            ip = ipaddress.ip_address(host)
         except ValueError:
             # ValueError is raised if the given address wasn't valid
             # this means it's a hostname and we should try to resolve

--- a/mcstatus/address.py
+++ b/mcstatus/address.py
@@ -126,7 +126,7 @@ class Address(_AddressBase):
             return self._cached_ip
 
         host = self.host
-        if self.host != "localhost" and sys.platform != "darwin":
+        if self.host == "localhost" and sys.platform == "darwin":
             host = "127.0.0.1"
             warnings.warn(
                 "On macOS because of some mysterious reasons we can't resolve localhost into IP. "

--- a/mcstatus/address.py
+++ b/mcstatus/address.py
@@ -157,7 +157,7 @@ class Address(_AddressBase):
             return self._cached_ip
 
         host = self.host
-        if self.host != "localhost" and sys.platform != "darwin":
+        if self.host == "localhost" and sys.platform == "darwin":
             host = "127.0.0.1"
             warnings.warn(
                 "On macOS because of some mysterious reasons we can't resolve localhost into IP. "

--- a/mcstatus/address.py
+++ b/mcstatus/address.py
@@ -124,7 +124,9 @@ class Address(_AddressBase):
             return self._cached_ip
 
         try:
-            ip = ipaddress.ip_address(self.host)
+            # On MacOS because of some mysterious reasons we can't resolve
+            # localhost into IP using `ipaddress.ip_address`.
+            ip = ipaddress.ip_address(self.host if self.host != "localhost" else "127.0.0.1")
         except ValueError:
             # ValueError is raised if the given address wasn't valid
             # this means it's a hostname and we should try to resolve
@@ -145,7 +147,9 @@ class Address(_AddressBase):
             return self._cached_ip
 
         try:
-            ip = ipaddress.ip_address(self.host)
+            # On MacOS because of some mysterious reasons we can't resolve
+            # localhost into IP using `ipaddress.ip_address`.
+            ip = ipaddress.ip_address(self.host if self.host != "localhost" else "127.0.0.1")
         except ValueError:
             # ValueError is raised if the given address wasn't valid
             # this means it's a hostname and we should try to resolve

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import warnings
 from abc import ABC
 from typing import TYPE_CHECKING
-
-import dns.resolver
 
 from mcstatus.address import Address, async_minecraft_srv_address_lookup, minecraft_srv_address_lookup
 from mcstatus.bedrock_status import BedrockServerStatus
@@ -155,16 +152,7 @@ class JavaServer(MCServer):
 
     def query(self) -> QueryResponse:
         """Checks the status of a Minecraft Java Edition server via the query protocol."""
-        # TODO: WARNING: This try-except for NXDOMAIN is only done because
-        # of failing tests on mac-os, which for some reason can't resolve 'localhost'
-        # into '127.0.0.1'. This try-except needs to be removed once this issue
-        # is resolved!
-        try:
-            ip = str(self.address.resolve_ip())
-        except dns.resolver.NXDOMAIN:
-            warnings.warn(f"Resolving IP for {self.address.host} failed with NXDOMAIN", stacklevel=1)
-            ip = self.address.host
-
+        ip = str(self.address.resolve_ip())
         return self._retry_query(Address(ip, self.address.port))
 
     @retry(tries=3)
@@ -176,16 +164,7 @@ class JavaServer(MCServer):
 
     async def async_query(self) -> QueryResponse:
         """Asynchronously checks the status of a Minecraft Java Edition server via the query protocol."""
-        # TODO: WARNING: This try-except for NXDOMAIN is only done because
-        # of failing tests on mac-os, which for some reason can't resolve 'localhost'
-        # into '127.0.0.1'. This try-except needs to be removed once this issue
-        # is resolved!
-        try:
-            ip = str(await self.address.async_resolve_ip())
-        except dns.resolver.NXDOMAIN:
-            warnings.warn(f"Resolving IP for {self.address.host} failed with NXDOMAIN", stacklevel=1)
-            ip = self.address.host
-
+        ip = str(await self.address.async_resolve_ip())
         return await self._retry_async_query(Address(ip, self.address.port))
 
     @retry(tries=3)

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -209,9 +210,15 @@ class TestAddressIPResolving:
 
     def test_resolve_localhost(self):
         addr = Address("localhost", 25565)
-        assert addr.resolve_ip() == ipaddress.ip_address("127.0.0.1")
+
+        context_manager = pytest.warns(RuntimeWarning) if sys.platform == "darwin" else MagicMock()
+        with context_manager:
+            assert addr.resolve_ip() == ipaddress.ip_address("127.0.0.1")
 
     @pytest.mark.asyncio
     async def test_async_resolve_localhost(self):
         addr = Address("localhost", 25565)
-        assert await addr.async_resolve_ip() == ipaddress.ip_address("127.0.0.1")
+
+        context_manager = pytest.warns(RuntimeWarning) if sys.platform == "darwin" else MagicMock()
+        with context_manager:
+            assert await addr.async_resolve_ip() == ipaddress.ip_address("127.0.0.1")

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -206,3 +206,12 @@ class TestAddressIPResolving:
             resolve.assert_not_called()  # Make sure we didn't needlessly try to resolve
             assert isinstance(resolved_ip, ipaddress.IPv6Address)
             assert str(resolved_ip) == self.ipv6_addr.host
+
+    def test_resolve_localhost(self):
+        addr = Address("localhost", 25565)
+        assert addr.resolve_ip() == ipaddress.ip_address("127.0.0.1")
+
+    @pytest.mark.asyncio
+    async def test_async_resolve_localhost(self):
+        addr = Address("localhost", 25565)
+        assert await addr.async_resolve_ip() == ipaddress.ip_address("127.0.0.1")


### PR DESCRIPTION
This bug exists deep inside MacOS, so we can't do anything better, than `if` statement, that will replace `localhost` with `127.0.0.1`.

BTW, `socket.getaddrinfo('localhost', 0)` returns `::1` twice and `127.0.0.1` twice too.