### PR TITLE
Accept tries counter for query functions

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -150,7 +150,7 @@ class JavaServer(MCServer):
         result = await pinger.read_status()
         return result
 
-    def query(self, tries: int = 3) -> QueryResponse:
+    def query(self, *, tries: int = 3) -> QueryResponse:
         """Checks the status of a Minecraft Java Edition server via the query protocol.
 
         :param tries: The number of times to retry if an error is encountered.
@@ -166,7 +166,7 @@ class JavaServer(MCServer):
             querier.handshake()
             return querier.read_query()
 
-    async def async_query(self, tries: int = 3) -> QueryResponse:
+    async def async_query(self, *, tries: int = 3) -> QueryResponse:
         """Asynchronously checks the status of a Minecraft Java Edition server via the query protocol.
 
         :param tries: The number of times to retry if an error is encountered.

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -150,25 +150,33 @@ class JavaServer(MCServer):
         result = await pinger.read_status()
         return result
 
-    def query(self) -> QueryResponse:
-        """Checks the status of a Minecraft Java Edition server via the query protocol."""
+    def query(self, tries: int = 3) -> QueryResponse:
+        """Checks the status of a Minecraft Java Edition server via the query protocol.
+
+        :param tries: The number of times to retry if an error is encountered.
+        :return: Query information in a :class:`~mcstatus.querier.QueryResponse` instance.
+        """
         ip = str(self.address.resolve_ip())
-        return self._retry_query(Address(ip, self.address.port))
+        return self._retry_query(Address(ip, self.address.port), tries=tries)
 
     @retry(tries=3)
-    def _retry_query(self, addr: Address) -> QueryResponse:
+    def _retry_query(self, addr: Address, **_kwargs) -> QueryResponse:
         with UDPSocketConnection(addr, self.timeout) as connection:
             querier = ServerQuerier(connection)
             querier.handshake()
             return querier.read_query()
 
-    async def async_query(self) -> QueryResponse:
-        """Asynchronously checks the status of a Minecraft Java Edition server via the query protocol."""
+    async def async_query(self, tries: int = 3) -> QueryResponse:
+        """Asynchronously checks the status of a Minecraft Java Edition server via the query protocol.
+
+        :param tries: The number of times to retry if an error is encountered.
+        :return: Query information in a :class:`~mcstatus.querier.QueryResponse` instance.
+        """
         ip = str(await self.address.async_resolve_ip())
-        return await self._retry_async_query(Address(ip, self.address.port))
+        return await self._retry_async_query(Address(ip, self.address.port), tries=tries)
 
     @retry(tries=3)
-    async def _retry_async_query(self, address: Address) -> QueryResponse:
+    async def _retry_async_query(self, address: Address, **_kwargs) -> QueryResponse:
         async with UDPAsyncSocketConnection(address, self.timeout) as connection:
             querier = AsyncServerQuerier(connection)
             await querier.handshake()


### PR DESCRIPTION
Per [Discord from @ItsDrike](https://discord.com/channels/936788458939224094/938623566964981802/1150384415592153118), 
> hm, I just noticed that we don't take **kwargs in JavaServer.query, and pass them over to _retry_query, like we do with status, this makes it impossible to do JavaServer.query(tries=1), whcih would be caught by the retry decorator, forcing people to always make 3 retires.

This should fix that.
