### PR TITLE
Improve MOTD simplifies

### DIFF
--- a/mcstatus/motd/__init__.py
+++ b/mcstatus/motd/__init__.py
@@ -5,7 +5,7 @@ import typing as t
 from dataclasses import dataclass
 
 from mcstatus.motd.components import Formatting, MinecraftColor, ParsedMotdComponent, TranslationTag, WebColor
-from mcstatus.motd.simplifies import get_unused_elements
+from mcstatus.motd.simplifies import get_unused_elements, squash_nearby_strings
 from mcstatus.motd.transformers import AnsiTransformer, HtmlTransformer, MinecraftTransformer, PlainTransformer
 
 if t.TYPE_CHECKING:
@@ -182,6 +182,7 @@ class Motd:
             unused_elements = get_unused_elements(parsed)
             parsed = [el for index, el in enumerate(parsed) if index not in unused_elements]
 
+        parsed = squash_nearby_strings(parsed)
         return __class__(parsed, self.raw, bedrock=self.bedrock)
 
     def to_plain(self) -> str:

--- a/mcstatus/motd/simplifies.py
+++ b/mcstatus/motd/simplifies.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 
 from mcstatus.motd.components import Formatting, MinecraftColor, ParsedMotdComponent, WebColor
 
-_PARSED_MOTD_COMPONENTS_TYPEVAR = t.TypeVar("_PARSED_MOTD_COMPONENTS_TYPEVAR", bound=list[ParsedMotdComponent])
+_PARSED_MOTD_COMPONENTS_TYPEVAR = t.TypeVar("_PARSED_MOTD_COMPONENTS_TYPEVAR", bound="list[ParsedMotdComponent]")
 
 
 def get_unused_elements(parsed: Sequence[ParsedMotdComponent]) -> set[int]:


### PR DESCRIPTION
They handle now 3 more scenarios:
- Meaningless resets and colors (`&a1&a2` -> `&a12`)
- Nearby strings (`["123", "456"]` -> `["123456"]`)
- Spaces between duplicated formattings/colors (`&a &a1` -> `&a 1`)

I also added a test which ensures that we don't remove strings that are only spaces (because I had such an idea in TODO, but then realized that spaces can be used as delimiters).

### Example

Unedited MOTD from our Discord chat:

```
§r                  §r§l§r§l§aS§r§l§aE§r§l§aR§r§l§aV§r§l§aE§r§l§aR§r §r§f| §r§7[1.19-19.2]§r
§r  §r§aW§r§ae§r§al§r§ac§r§ao§r§am§r§ae§r §r§at§r§ao§r §r§at§r§ah§r§ae§r §r§am§r§ao§r§as§r§at§r §r§af§r§au§r§an§r §r§aa§r§an§r§ad§r §r§ad§r§ae§r§ad§r§ai§r§ac§r§aa§r§at§r§ae§r§ad§r §r§ac§r§ao§r§am§r§am§r§au§r§an§r§ai§r§at§r§ey§r§e!§r
```

is now transformed into

```
                  §aSERVER §f| §7[1.19-19.2]
  §aWelcome to the most fun and dedicated communit§ey!
```

but before was

```
§r                  §aS§aE§aR§aV§aE§aR§r §f| §7[1.19-19.2]§r
§r  §aW§ae§al§ac§ao§am§ae§r §at§ao§r §at§ah§ae§r §am§ao§as§at§r §af§au§an§r §aa§an§ad§r §ad§ae§ad§ai§ac§aa§at§ae§ad§r §ac§ao§am§am§au§an§ai§at§ey§e!
```

---

P.S. It may be a breaking change, because now it gives much less number of elements, than it was before. But it should be expected, and no public API was changed.