### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/mcstatus/motd/components.py
+++ b/mcstatus/motd/components.py
@@ -11,7 +11,7 @@ if t.TYPE_CHECKING:
 class Formatting(Enum):
     """Enum for Formatting codes.
 
-    See `Minecraft wiki <https://minecraft.fandom.com/wiki/Formatting_codes#Formatting_codes>`__
+    See `Minecraft wiki <https://minecraft.wiki/w/Formatting_codes#Formatting_codes>`__
     for more info.
 
     .. note::
@@ -30,7 +30,7 @@ class Formatting(Enum):
 class MinecraftColor(Enum):
     """Enum for Color codes.
 
-    See `Minecraft wiki <https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes>`_
+    See `Minecraft wiki <https://minecraft.wiki/w/Formatting_codes#Color_codes>`_
     for more info.
     """
 
@@ -117,7 +117,7 @@ class TranslationTag:
     This just exists, but is completely ignored by our transformers.
     You can find translation tags in :attr:`Motd.parsed <mcstatus.motd.Motd.parsed>` attribute.
 
-    .. seealso:: `Minecraft's wiki. <https://minecraft.fandom.com/wiki/Raw_JSON_text_format#Translated_Text>`__
+    .. seealso:: `Minecraft's wiki. <https://minecraft.wiki/w/Raw_JSON_text_format#Translated_Text>`__
     """
 
     id: str

--- a/mcstatus/status_response.py
+++ b/mcstatus/status_response.py
@@ -305,13 +305,13 @@ class BaseStatusVersion(ABC):
     name: str
     """The version name, like ``1.19.3``.
 
-    See `Minecraft wiki <https://minecraft.fandom.com/wiki/Java_Edition_version_history#Full_release>`__
+    See `Minecraft wiki <https://minecraft.wiki/w/Java_Edition_version_history#Full_release>`__
     for complete list.
     """
     protocol: int
     """The protocol version, like ``761``.
 
-    See `Minecraft wiki <https://minecraft.fandom.com/wiki/Protocol_version#Java_Edition_2>`__.
+    See `Minecraft wiki <https://minecraft.wiki/w/Protocol_version#Java_Edition_2>`__.
     """
 
 
@@ -339,7 +339,7 @@ class BedrockStatusVersion(BaseStatusVersion):
     name: str
     """The version name, like ``1.19.60``.
 
-    See `Minecraft wiki <https://minecraft.fandom.com/wiki/Bedrock_Edition_version_history#Bedrock_Edition>`__
+    See `Minecraft wiki <https://minecraft.wiki/w/Bedrock_Edition_version_history#Bedrock_Edition>`__
     for complete list.
     """
     brand: str


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki