### PR TITLE
Add enforces_secure_chat to JavaStatusResponse

### DIFF
--- a/mcstatus/status_response.py
+++ b/mcstatus/status_response.py
@@ -109,6 +109,7 @@ class JavaStatusResponse(BaseStatusResponse):
     """
     players: JavaStatusPlayers
     version: JavaStatusVersion
+    enforces_secure_chat: bool
     icon: str | None
     """The icon of the server. In `Base64 <https://en.wikipedia.org/wiki/Base64>`_ encoded PNG image format.
 
@@ -132,6 +133,7 @@ class JavaStatusResponse(BaseStatusResponse):
             players=JavaStatusPlayers.build(raw["players"]),
             version=JavaStatusVersion.build(raw["version"]),
             motd=Motd.parse(raw["description"], bedrock=False),
+            enforces_secure_chat=raw.get("enforcesSecureChat", False),
             icon=raw.get("favicon"),
             latency=latency,
         )

--- a/tests/status_response/test_java.py
+++ b/tests/status_response/test_java.py
@@ -1,4 +1,4 @@
-from pytest import fixture
+import pytest
 
 from mcstatus.motd import Motd
 from mcstatus.status_response import JavaStatusPlayer, JavaStatusPlayers, JavaStatusResponse, JavaStatusVersion
@@ -29,9 +29,15 @@ class TestJavaStatusResponse(BaseStatusResponseTest):
         "favicon": "data:image/png;base64,foo",
     }
 
-    @fixture(scope="class")
+    @pytest.fixture(scope="class")
     def build(self):
         return JavaStatusResponse.build(self.RAW)  # type: ignore # dict[str, Unknown] cannot be assigned to TypedDict
+
+    @pytest.mark.parametrize("value", (True, False, object()))
+    def test_enforces_secure_chat(self, value):
+        raw = self.RAW.copy()
+        raw["enforcesSecureChat"] = value
+        assert JavaStatusResponse.build(raw, 0).enforces_secure_chat is value  # type: ignore # dict[str, Unknown] cannot be assigned to TypedDict
 
 
 @BaseStatusResponseTest.construct
@@ -58,7 +64,7 @@ class TestJavaStatusPlayers(BaseStatusResponseTest):
         ],
     }
 
-    @fixture(scope="class")
+    @pytest.fixture(scope="class")
     def build(self):
         return JavaStatusPlayers.build(
             {
@@ -80,7 +86,7 @@ class TestJavaStatusPlayers(BaseStatusResponseTest):
 class TestJavaStatusPlayer(BaseStatusResponseTest):
     EXPECTED_VALUES = [("name", "foo"), ("id", "0b3717c4-f45d-47c8-b8e2-3d9ff6f93a89")]
 
-    @fixture(scope="class")
+    @pytest.fixture(scope="class")
     def build(self):
         return JavaStatusPlayer.build({"name": "foo", "id": "0b3717c4-f45d-47c8-b8e2-3d9ff6f93a89"})
 
@@ -96,6 +102,6 @@ class TestJavaStatusPlayer(BaseStatusResponseTest):
 class TestJavaStatusVersion(BaseStatusResponseTest):
     EXPECTED_VALUES = [("name", "1.8-pre1"), ("protocol", 44)]
 
-    @fixture(scope="class")
+    @pytest.fixture(scope="class")
     def build(self):
         return JavaStatusVersion.build({"name": "1.8-pre1", "protocol": 44})


### PR DESCRIPTION
Was surprised to see this wasn't present even tho it's in the raw json response when enforce-secure-profile is enabled.

Just 2 simple lines, didn't add any test.