### PR TITLE
Enforces secure chat improvements

### DIFF
--- a/mcstatus/status_response.py
+++ b/mcstatus/status_response.py
@@ -109,7 +109,7 @@ class JavaStatusResponse(BaseStatusResponse):
     """
     players: JavaStatusPlayers
     version: JavaStatusVersion
-    enforces_secure_chat: bool
+    enforces_secure_chat: bool | None
     icon: str | None
     """The icon of the server. In `Base64 <https://en.wikipedia.org/wiki/Base64>`_ encoded PNG image format.
 
@@ -133,7 +133,7 @@ class JavaStatusResponse(BaseStatusResponse):
             players=JavaStatusPlayers.build(raw["players"]),
             version=JavaStatusVersion.build(raw["version"]),
             motd=Motd.parse(raw["description"], bedrock=False),
-            enforces_secure_chat=raw.get("enforcesSecureChat", False),
+            enforces_secure_chat=raw.get("enforcesSecureChat"),
             icon=raw.get("favicon"),
             latency=latency,
         )

--- a/mcstatus/status_response.py
+++ b/mcstatus/status_response.py
@@ -111,12 +111,12 @@ class JavaStatusResponse(BaseStatusResponse):
     version: JavaStatusVersion
     enforces_secure_chat: bool | None
     """Whether the server enforces secure chat (every message is signed up with a key).
-    
+
     .. seealso::
         `Signed Chat explanation <https://gist.github.com/kennytv/ed783dd244ca0321bbd882c347892874>`_,
         `22w17a changelog, where this was added <https://www.minecraft.net/nl-nl/article/minecraft-snapshot-22w17a>`_.
-        
-    .. versionadded:: 11.1.0 
+
+    .. versionadded:: 11.1.0
     """
     icon: str | None
     """The icon of the server. In `Base64 <https://en.wikipedia.org/wiki/Base64>`_ encoded PNG image format.

--- a/mcstatus/status_response.py
+++ b/mcstatus/status_response.py
@@ -110,6 +110,14 @@ class JavaStatusResponse(BaseStatusResponse):
     players: JavaStatusPlayers
     version: JavaStatusVersion
     enforces_secure_chat: bool | None
+    """Whether the server enforces secure chat (every message is signed up with a key).
+    
+    .. seealso::
+        `Signed Chat explanation <https://gist.github.com/kennytv/ed783dd244ca0321bbd882c347892874>`_,
+        `22w17a changelog, where this was added <https://www.minecraft.net/nl-nl/article/minecraft-snapshot-22w17a>`_.
+        
+    .. versionadded:: 11.1.0 
+    """
     icon: str | None
     """The icon of the server. In `Base64 <https://en.wikipedia.org/wiki/Base64>`_ encoded PNG image format.
 

--- a/tests/status_response/test_java.py
+++ b/tests/status_response/test_java.py
@@ -11,6 +11,7 @@ class TestJavaStatusResponse(BaseStatusResponseTest):
         "players": {"max": 20, "online": 0},
         "version": {"name": "1.8-pre1", "protocol": 44},
         "description": "A Minecraft Server",
+        "enforcesSecureChat": True,
         "favicon": "data:image/png;base64,foo",
     }
 
@@ -19,25 +20,21 @@ class TestJavaStatusResponse(BaseStatusResponseTest):
         ("version", JavaStatusVersion("1.8-pre1", 44)),
         ("motd", Motd.parse("A Minecraft Server", bedrock=False)),
         ("latency", 0),
+        ("enforces_secure_chat", True),
         ("icon", "data:image/png;base64,foo"),
         ("raw", RAW),
     ]
-    OPTIONAL_FIELDS = [("favicon", "icon")], {
+    OPTIONAL_FIELDS = [("favicon", "icon"), ("enforcesSecureChat", "enforces_secure_chat")], {
         "players": {"max": 20, "online": 0},
         "version": {"name": "1.8-pre1", "protocol": 44},
         "description": "A Minecraft Server",
+        "enforcesSecureChat": True,
         "favicon": "data:image/png;base64,foo",
     }
 
     @pytest.fixture(scope="class")
     def build(self):
         return JavaStatusResponse.build(self.RAW)  # type: ignore # dict[str, Unknown] cannot be assigned to TypedDict
-
-    @pytest.mark.parametrize("value", (True, False, object()))
-    def test_enforces_secure_chat(self, value):
-        raw = self.RAW.copy()
-        raw["enforcesSecureChat"] = value
-        assert JavaStatusResponse.build(raw, 0).enforces_secure_chat is value  # type: ignore # dict[str, Unknown] cannot be assigned to TypedDict
 
 
 @BaseStatusResponseTest.construct


### PR DESCRIPTION
I looked at 1a2badd9db7b1b5c128889285037a1fb4c25f0c7 and realized it can be done better.

Preview docs [here](https://mcstatus--678.org.readthedocs.build/en/678/api/basic/#mcstatus.status_response.JavaStatusResponse.enforces_secure_chat).

Related: #675.