### PR TITLE
Enable pre-commit.ci and enable config file sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,10 @@
+ci:
+  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: weekly
+  submodules: false
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
@@ -8,13 +15,15 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
-
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: sort-simple-yaml
+        files: .pre-commit-config.yaml
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.5.1
     hooks:
       - id: python-check-blanket-noqa # Enforce noqa annotations (noqa: F401,W203)
       - id: python-use-type-annotations # Enforce type annotations instead of type comments
-
   - repo: local
     hooks:
       - id: black
@@ -23,7 +32,6 @@ repos:
         entry: poetry run black
         language: system
         types: [python]
-
   - repo: local
     hooks:
       - id: ruff
@@ -34,7 +42,6 @@ repos:
         types: [python]
         require_serial: true
         args: [--fix, --exit-non-zero-on-fix]
-
   - repo: local
     hooks:
       - id: isort
@@ -43,7 +50,6 @@ repos:
         entry: poetry run isort
         language: system
         types: [python]
-
   - repo: local
     hooks:
       - id: pyright


### PR DESCRIPTION
Closes #694
This pull request enables pre-commit.ci and enables a few of the other https://github.com/pre-commit/pre-commit-hooks fixes, these being `end-of-file-fixer`, `mixed-line-ending`, and `sort-simple-yaml`. 

`sort-simple-yaml` in particular is only sorting the pre-commit config file so that future changes will be in an ordered fashion.

Edit:
One important detail, someone who is an owner of the repository/github organization has to give pre-commit.ci access to the repository so whatever bot they have can make the pull requests. You can find it on their official site at https://pre-commit.ci/