### PR TITLE
Use offical pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,14 +9,15 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-      - id: check-merge-conflict
-      - id: check-toml # For pyproject.toml
-      - id: check-yaml # For workflows
-      - id: end-of-file-fixer
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
       - id: end-of-file-fixer
+      - id: check-ast
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
       - id: mixed-line-ending
+      - id: check-case-conflict
       - id: sort-simple-yaml
         files: .pre-commit-config.yaml
   - repo: https://github.com/pre-commit/pygrep-hooks
@@ -24,38 +25,29 @@ repos:
     hooks:
       - id: python-check-blanket-noqa # Enforce noqa annotations (noqa: F401,W203)
       - id: python-use-type-annotations # Enforce type annotations instead of type comments
-  - repo: local
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.12.0
     hooks:
       - id: black
-        name: Black
-        description: Auto-format the code with black
-        entry: poetry run black
-        language: system
-        types: [python]
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.8
     hooks:
       - id: ruff
-        name: Ruff
-        description: Run ruff checks on the code
-        entry: poetry run ruff check --force-exclude
-        language: system
-        types: [python]
+        types: [file]
+        types_or: [python, pyi, toml]
         require_serial: true
         args: [--fix, --exit-non-zero-on-fix]
-  - repo: local
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
       - id: isort
-        name: ISort
-        description: Sort imports with isort
-        entry: poetry run isort
-        language: system
-        types: [python]
-  - repo: local
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.341
     hooks:
-      - id: pyright
-        name: Pyright
-        description: Run pyright type checker
-        entry: poetry run pyright
-        language: system
-        types: [python]
-        pass_filenames: false # pyright runs for the entire project, it can't run for single files
+    - id: pyright
+      types: [python]
+      pass_filenames: false # pyright runs for the entire project, it can't run for single files
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell

--- a/docs/examples/code/player_list_from_query_with_fallback_on_status.py
+++ b/docs/examples/code/player_list_from_query_with_fallback_on_status.py
@@ -9,6 +9,6 @@ else:
     status = server.status()
 
     if not status.players.sample:
-        print("Cant find players list, no one online or the server disabled this.")
+        print("Can't find players list, no one online or the server disabled this.")
     else:
         print("Players online:", ", ".join([player.name for player in status.players.sample]))

--- a/mcstatus/querier.py
+++ b/mcstatus/querier.py
@@ -92,7 +92,7 @@ class AsyncServerQuerier(ServerQuerier):
 class QueryResponse:
     """Documentation for this class is written by hand, without docstrings.
 
-    This is because the class is not supposted to be auto-documented.
+    This is because the class is not supposed to be auto-documented.
 
     Please see https://mcstatus.readthedocs.io/en/latest/api/basic/#mcstatus.querier.QueryResponse
     for the actual documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,10 +96,11 @@ style = "pep440"
 [tool.ruff]
 target-version = "py38"
 line-length = 127
+fix = true
 
 select = [
     "F",     # Pyflakes
-    "W",     # Pycodestyle (warnigns)
+    "W",     # Pycodestyle (warnings)
     "E",     # Pycodestyle (errors)
     "N",     # pep8-naming
     "ANN",   # flake8-annotations
@@ -133,6 +134,9 @@ ban-relative-imports = "all"
 
 [tool.black]
 line-length = 127
+
+[tool.codespell]
+ignore-words-list = 'formattings,curios'
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Closes #705
This pull request changes the pre-commit hooks to use the official hooks that are suggested to be used for all the projects that already have hooks, instead of using `poetry run <xxx>` for everything, which can fail because nothing specifically ensures that the projects we use are installed on the host system, which is particularly an issue for pre-commit.ci, which never installs anything locally and only uses virtual environments and such for running the hooks.

This might be up for debate and I realize I should probably have made this a separate change, but I also added codespell to the project, which I've found incredibly helpful in the past in some of my own projects that helps with spelling issues. If required I could make this change in a new pull request instead.

In the idea of moving everything to the official pre-commit hooks, I came across the fact that pyright doesn't have an 'official' so to say pre-commit hook, but their offical docs say to use a community-maintained wrapper hook (https://github.com/microsoft/pyright/blob/main/docs/ci-integration.md), which is the one I changed it to use. Personally I think it might be unwise to use pyright as a pre-commit hook, because I was noticing that it makes commits incredibly slow. I would rather run pyright manually or let CI find the issues for me than slowing down committing, but I've left it in this pull request and would suggest we put this issue up for debate.