### PR TITLE
Use pymine-ci-bot app to enable PR auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,20 +10,27 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.CI_BOT_APP_ID }}
+          private_key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
+
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ steps.generate_token.outputs.token }}"
 
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
The auto-merge workflow for dependabot PRs introduced in #714 doesn't actually work as it should. That's because it's attempting to enable auto-merge on a PR targetting our `master` branch, which is marked as a protected branch, for which just using `${{ secrets.GITHUB_TOKEN }}` is not sufficient. 

This ultimately shows up as a failure of this CI, on the auto-merge enabling step, with the following message:
```
GraphQL: Pull request User is not authorized for this protected branch (enablePullRequestAutoMerge)
```

This PR moves away from using the `GITHUB_TOKEN` to a custom github app, registered for the organization ([here](https://github.com/organizations/py-mine/settings/installations/32657600) - link only available to organization admins). 

That means the author shown for the PR approval review and the auto-merge enable action will now show  `@py-mine-ci-bot[bot]` account, instead of the `@github-actions[bot]` account.

Alongside with this PR, I've made the following changes to organization/repostiory settings:
- Enabled access to `mcstatus` repository for the pymine-ci-bot application, giving it both read and write access to this repo.
- Generated a new private key for the `pymine-ci-bot` application, and stored it's content as a secret on this repository, under `CI_BOT_PRIVATE_KEY` variable.
- Added `CI_BOT_APP_ID` secret to this repository (even though this isn't really a secret, it doesn't matter if this variable gets leaked)

