### PR TITLE
Use official `actions/create-github-app-token` for auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,26 +11,26 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v2
+        id: app-token
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.CI_BOT_APP_ID }}
-          private_key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
 
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1
         with:
-          github-token: "${{ steps.generate_token.outputs.token }}"
+          github-token: "${{ steps.app-token.outputs.token }}"
 
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Currently [CI fails](https://github.com/py-mine/mcstatus/actions/runs/7746248529/job/21124042371?pr=735) with:

```
Run tibdex/github-app-token@v2
  with:
    github_api_url: https://api.github.com/
    installation_retrieval_mode: repository
    installation_retrieval_payload: py-mine/mcstatus
    revoke: true

Error: Input required and not supplied: app_id
    at getInput (file:///home/runner/work/_actions/tibdex/github-app-token/v2/dist/main/index.js:1:3828)
    at parseOptions (file:///home/runner/work/_actions/tibdex/github-app-token/v2/dist/main/index.js:9:87889)
    at file:///home/runner/work/_actions/tibdex/github-app-token/v2/dist/main/index.js:9:87507
    at run (file:///home/runner/work/_actions/tibdex/github-app-token/v2/dist/main/index.js:9:88817)
    at file:///home/runner/work/_actions/tibdex/github-app-token/v2/dist/main/index.js:9:87480
    at __nccwpck_require__.a (file:///home/runner/work/_actions/tibdex/github-app-token/v2/dist/main/index.js:9:368729)
    at 399 (file:///home/runner/work/_actions/tibdex/github-app-token/v2/dist/main/index.js:9:87363)
    at __nccwpck_require__ (file:///home/runner/work/_actions/tibdex/github-app-token/v2/dist/main/index.js:9:367817)
    at file:///home/runner/work/_actions/tibdex/github-app-token/v2/dist/main/index.js:9:369615
    at ModuleJob.run (node:internal/modules/esm/module_job:217:25)
```

Firstly I thought ItsDrike forgot to add `app_id` argument, but it is false. Then I looked at [`tibdex/github-app-token`'s issue tracker](https://github.com/tibdex/github-app-token/issues) and found https://github.com/tibdex/github-app-token/issues/99. 

So this issue is probably a bug somewhere in the action, but as there is [an official alternative](https://github.com/actions/create-github-app-token) to this GH action, why not use it instead? Furthermore, it seems to be actively maintained, so we shouldn't face such fundamental errors.