### PR TITLE
Use `on: pull_request_target` to allow secrets in dependabot auto-merge CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,5 @@
 name: Dependabot auto-merge
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: write


### PR DESCRIPTION
While I was filling a new issue on [actions/create-github-app-token](https://github.com/actions/create-github-app-token), I thought that GitHub probably replaces secrets with empty strings on PRs for safety reasons. It happens to be true.

Referring to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/, `on: pull_request_target` should allow using secrets, and it is safe for us, because we skip action if PR author is not `dependabot[bot]`.