### PR TITLE
Make all our dataclasses frozen

### DIFF
--- a/mcstatus/motd/__init__.py
+++ b/mcstatus/motd/__init__.py
@@ -20,7 +20,7 @@ __all__ = ["Motd"]
 MOTD_COLORS_RE = re.compile(r"([\xA7|&][0-9A-FK-OR])", re.IGNORECASE)
 
 
-@dataclass
+@dataclass(frozen=True)
 class Motd:
     """Represents parsed MOTD."""
 

--- a/mcstatus/motd/components.py
+++ b/mcstatus/motd/components.py
@@ -55,7 +55,7 @@ class MinecraftColor(Enum):
     MINECOIN_GOLD = "g"
 
 
-@dataclass
+@dataclass(frozen=True)
 class WebColor:
     """Raw HTML color from MOTD.
 
@@ -110,7 +110,7 @@ class WebColor:
                 raise ValueError(f"RGB color byte out of its 8-bit range (0-255) for {color_name} ({value=})")
 
 
-@dataclass
+@dataclass(frozen=True)
 class TranslationTag:
     """Represents a ``translate`` field in server's answer.
 

--- a/mcstatus/status_response.py
+++ b/mcstatus/status_response.py
@@ -64,7 +64,7 @@ __all__ = [
 ]
 
 
-@dataclass
+@dataclass(frozen=True)
 class BaseStatusResponse(ABC):
     """Class for storing shared data from a status response."""
 
@@ -97,7 +97,7 @@ class BaseStatusResponse(ABC):
         raise NotImplementedError("You can't use abstract methods.")
 
 
-@dataclass
+@dataclass(frozen=True)
 class JavaStatusResponse(BaseStatusResponse):
     """The response object for :meth:`JavaServer.status() <mcstatus.server.JavaServer.status>`."""
 
@@ -146,7 +146,7 @@ class JavaStatusResponse(BaseStatusResponse):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class BedrockStatusResponse(BaseStatusResponse):
     """The response object for :meth:`BedrockServer.status() <mcstatus.server.BedrockServer.status>`."""
 
@@ -192,7 +192,7 @@ class BedrockStatusResponse(BaseStatusResponse):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class BaseStatusPlayers(ABC):
     """Class for storing information about players on the server."""
 
@@ -202,7 +202,7 @@ class BaseStatusPlayers(ABC):
     """The maximum allowed number of players (aka server slots)."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class JavaStatusPlayers(BaseStatusPlayers):
     """Class for storing information about players on the server."""
 
@@ -239,12 +239,12 @@ class JavaStatusPlayers(BaseStatusPlayers):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class BedrockStatusPlayers(BaseStatusPlayers):
     """Class for storing information about players on the server."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class JavaStatusPlayer:
     """Class with information about a single player."""
 
@@ -271,7 +271,7 @@ class JavaStatusPlayer:
         return cls(name=raw["name"], id=raw["id"])
 
 
-@dataclass
+@dataclass(frozen=True)
 class BaseStatusVersion(ABC):
     """A class for storing version information."""
 
@@ -288,7 +288,7 @@ class BaseStatusVersion(ABC):
     """
 
 
-@dataclass
+@dataclass(frozen=True)
 class JavaStatusVersion(BaseStatusVersion):
     """A class for storing version information."""
 
@@ -305,7 +305,7 @@ class JavaStatusVersion(BaseStatusVersion):
         return cls(name=raw["name"], protocol=raw["protocol"])
 
 
-@dataclass
+@dataclass(frozen=True)
 class BedrockStatusVersion(BaseStatusVersion):
     """A class for storing version information."""
 

--- a/tests/status_response/test_java.py
+++ b/tests/status_response/test_java.py
@@ -88,11 +88,10 @@ class TestJavaStatusPlayer(BaseStatusResponseTest):
         return JavaStatusPlayer.build({"name": "foo", "id": "0b3717c4-f45d-47c8-b8e2-3d9ff6f93a89"})
 
     def test_id_field_the_same_as_uuid(self):
-        build = JavaStatusPlayer.build({"name": "foo", "id": "0b3717c4-f45d-47c8-b8e2-3d9ff6f93a89"})
+        unique = object()
+        build = JavaStatusPlayer.build({"name": "foo", "id": unique})  # type: ignore[assignment]
         assert build.id is build.uuid
-
-        build.id = unique = object()  # type: ignore[assignment]
-        assert unique is build.uuid
+        assert build.uuid is unique
 
 
 @BaseStatusResponseTest.construct


### PR DESCRIPTION
This fixes some of the errors that pyright [outputs](https://github.com/py-mine/mcstatus/actions/runs/7789626721/job/21241666878?pr=741) after an update:
```
/home/runner/work/mcstatus/mcstatus/mcstatus/status_response.py
  /home/runner/work/mcstatus/mcstatus/mcstatus/status_response.py:109:5 - error: "players" overrides symbol of same name in class "BaseStatusResponse"
    Variable is mutable so its type is invariant
      Override type "JavaStatusPlayers" is not the same as base type "BaseStatusPlayers" (reportIncompatibleVariableOverride)
  /home/runner/work/mcstatus/mcstatus/mcstatus/status_response.py:110:5 - error: "version" overrides symbol of same name in class "BaseStatusResponse"
    Variable is mutable so its type is invariant
      Override type "JavaStatusVersion" is not the same as base type "BaseStatusVersion" (reportIncompatibleVariableOverride)
  /home/runner/work/mcstatus/mcstatus/mcstatus/status_response.py:153:5 - error: "players" overrides symbol of same name in class "BaseStatusResponse"
    Variable is mutable so its type is invariant
      Override type "BedrockStatusPlayers" is not the same as base type "BaseStatusPlayers" (reportIncompatibleVariableOverride)
  /home/runner/work/mcstatus/mcstatus/mcstatus/status_response.py:154:5 - error: "version" overrides symbol of same name in class "BaseStatusResponse"
    Variable is mutable so its type is invariant
      Override type "BedrockStatusVersion" is not the same as base type "BaseStatusVersion" (reportIncompatibleVariableOverride)
```

This is probably a breaking change (you can't change the values of returned objects anymore), although we already have a breaking change (#682) in our master, so it is not a big deal I think.