### PR TITLE
Move to ruff-formatter & update settings

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -31,8 +31,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
-          key: "precommit-${{ runner.os }}-${{ steps.poetry_setup.outputs.python-version }}-\
-                ${{ hashFiles('./.pre-commit-config.yaml') }}"
+          key:
+            "precommit-${{ runner.os }}-${{ steps.poetry_setup.outputs.python-version }}-\
+            ${{ hashFiles('./.pre-commit-config.yaml') }}"
           # Restore keys allows us to perform a cache restore even if the full cache key wasn't matched.
           # That way we still end up saving new cache, but we can still make use of the cache from previous
           # version.
@@ -41,17 +42,14 @@ jobs:
       - name: Run pre-commit hooks
         run: SKIP=black,isort,ruff,pyright pre-commit run --all-files
 
-      - name: Run black formatter check
-        run: black --check --diff .
+      - name: Run ruff linter
+        run: ruff check --output-format=full --show-fixes --exit-non-zero-on-fix .
 
-      - name: Run isort import formatter check
-        run: isort --check .
+      - name: Run ruff formatter
+        run: ruff format --diff .
 
       - name: Run pyright type checker
         run: pyright .
-
-      - name: Run ruff linter
-        run: ruff check --show-source .
 
       # Steps below are here to generate and upload an artifact from
       # this workflow so that we can have the data about author and some

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,16 +26,8 @@ repos:
       - id: python-use-type-annotations # Enforce type annotations instead of type comments
   - repo: local
     hooks:
-      - id: black
-        name: Black
-        description: Auto-format the code with black
-        entry: poetry run black
-        language: system
-        types: [python]
-  - repo: local
-    hooks:
       - id: ruff
-        name: Ruff
+        name: Ruff Linter
         description: Run ruff checks on the code
         entry: poetry run ruff check --force-exclude
         language: system
@@ -44,12 +36,13 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
   - repo: local
     hooks:
-      - id: isort
-        name: ISort
-        description: Sort imports with isort
-        entry: poetry run isort
+      - id: ruff-ruff
+        name: Ruff Formatter
+        description: Ruf ruff auto-formatter
+        entry: poetry run ruff format
         language: system
         types: [python]
+        require_serial: true
   - repo: local
     hooks:
       - id: pyright

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,52 +58,6 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "black"
-version = "24.3.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "black-24.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395"},
-    {file = "black-24.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995"},
-    {file = "black-24.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7"},
-    {file = "black-24.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0"},
-    {file = "black-24.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9"},
-    {file = "black-24.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597"},
-    {file = "black-24.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d"},
-    {file = "black-24.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5"},
-    {file = "black-24.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f"},
-    {file = "black-24.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11"},
-    {file = "black-24.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4"},
-    {file = "black-24.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5"},
-    {file = "black-24.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:79dcf34b33e38ed1b17434693763301d7ccbd1c5860674a8f871bd15139e7837"},
-    {file = "black-24.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd"},
-    {file = "black-24.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65b76c275e4c1c5ce6e9870911384bff5ca31ab63d19c76811cb1fb162678213"},
-    {file = "black-24.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:b5991d523eee14756f3c8d5df5231550ae8993e2286b8014e2fdea7156ed0959"},
-    {file = "black-24.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c45f8dff244b3c431b36e3224b6be4a127c6aca780853574c00faf99258041eb"},
-    {file = "black-24.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6905238a754ceb7788a73f02b45637d820b2f5478b20fec82ea865e4f5d4d9f7"},
-    {file = "black-24.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7"},
-    {file = "black-24.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:7bb041dca0d784697af4646d3b62ba4a6b028276ae878e53f6b4f74ddd6db99f"},
-    {file = "black-24.3.0-py3-none-any.whl", hash = "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93"},
-    {file = "black-24.3.0.tar.gz", hash = "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "bleach"
 version = "6.0.0"
 description = "An easy safelist-based HTML-sanitizing tool."
@@ -350,20 +304,6 @@ files = [
 [package.dependencies]
 crashtest = ">=0.4.1,<0.5.0"
 rapidfuzz = ">=3.0.0,<4.0.0"
-
-[[package]]
-name = "click"
-version = "8.1.6"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"},
-    {file = "click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
@@ -794,20 +734,6 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "5.13.2"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.6)"]
-
-[[package]]
 name = "jaraco-classes"
 version = "3.3.0"
 description = "Utility functions for Python class constructs"
@@ -1095,17 +1021,6 @@ files = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.8.0"
 description = "Node.js virtual environment builder"
@@ -1128,17 +1043,6 @@ python-versions = ">=3.7"
 files = [
     {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
     {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
-]
-
-[[package]]
-name = "pathspec"
-version = "0.11.2"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
-    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
 ]
 
 [[package]]
@@ -2260,4 +2164,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4"
-content-hash = "3758c97e2975eec5128bc0201593bd63a6537c55ef64e8ef8cd7efe827bc9403"
+content-hash = "0cb8e9603af93feafb039bc6a3a23031e4635c0d4237a233e4129a73a7371fb0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 packages = [
     { include = "mcstatus" },
-    { include = "protocol", from = "mcstatus" }
+    { include = "protocol", from = "mcstatus" },
 ]
 
 [tool.poetry.dependencies]
@@ -48,9 +48,7 @@ coverage = "^7.3.0"
 
 [tool.poetry.group.lint.dependencies]
 ruff = "0.3.4"
-black = ">=23.7,<25.0"
 coverage = "^7.3.0"
-isort = "^5.12.0"
 pyright = "^1.1.322"
 typing-extensions = "^4.7.1"
 
@@ -97,6 +95,7 @@ style = "pep440"
 target-version = "py38"
 line-length = 127
 
+[tool.ruff.lint]
 select = [
     "F",     # Pyflakes
     "W",     # Pycodestyle (warnigns)
@@ -118,9 +117,24 @@ ignore = [
     "ANN204", # Missing return type annotation for special method
     "B904",   # Exception raised within try-except should use raise ... from exc
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
+
+    # Redundant rules with ruff-format:
+    "E111",   # Indentation of a non-multiple of 4 spaces
+    "E114",   # Comment with indentation  of a non-multiple of 4 spaces
+    "E117",   # Cheks for over-indented code
+    "D206",   # Checks for docstrings indented with tabs
+    "D300",   # Checks for docstring that use ''' instead of """
+    "Q000",   # Checks of inline strings that use wrong quotes (' instead of ")
+    "Q001",   # Multiline string that use wrong quotes (''' instead of """)
+    "Q002",   # Checks for docstrings that use wrong quotes (''' instead of """)
+    "Q003",   # Checks for avoidable escaped quotes ("\"" -> '"')
+    "COM812", # Missing trailing comma (in multi-line lists/tuples/...)
+    "COM819", # Prohibited trailing comma (in single-line lists/tuples/...)
+    "ISC001", # Single line implicit string concatenation ("hi" "hey" -> "hihey")
+    "ISC002", # Multi line implicit string concatenation
 ]
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "test_*.py" = [
     "ANN", # flake8-annotations
 ]
@@ -128,18 +142,23 @@ ignore = [
     "FA",  # flake8-future-annotations
 ]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.black]
-line-length = 127
+[tool.ruff.lint.isort]
+order-by-type = false
+case-sensitive = true
+combine-as-imports = true
 
-[tool.isort]
-profile = "black"
-line_length = 127
-order_by_type = false
-case_sensitive = true
-skip = [".venv", ".git", ".cache", ".tox"]
+# Redundant rules with ruff-format
+force-single-line = false       # forces all imports to appear on their own line
+force-wrap-aliases = false      # Split imports with multiple members and at least one alias
+lines-after-imports = -1        # The number of blank lines to place after imports
+lines-between-types = 0         # Number of lines to place between "direct" and import from imports
+split-on-trailing-comma = false # if last member of multiline import has a comma, don't fold it to single line
+
+[tool.ruff-formatter]
+line-ending = "lf"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/tests/motd/test_motd.py
+++ b/tests/motd/test_motd.py
@@ -11,7 +11,6 @@ class TestMotdParse:
     def test_correct_result(self, source):
         assert Motd.parse(source) == Motd(
             [
-                # fmt: off
                 "top", Formatting.RESET,
                 "1", Formatting.RESET,
                 WebColor.from_hex(hex="#b3eeff"), "2", Formatting.RESET,
@@ -35,10 +34,9 @@ class TestMotdParse:
                 MinecraftColor.MINECOIN_GOLD, "20", Formatting.RESET,
                 Formatting.RESET, "21", Formatting.RESET,
                 TranslationTag("some.random.string"), Formatting.RESET,
-                # fmt: on
             ],
             raw=source,
-        )
+        )  # fmt: skip
 
     @pytest.mark.parametrize("bedrock", (True, False))
     def test_bedrock_parameter_nothing_changes(self, bedrock: bool):
@@ -167,7 +165,6 @@ class TestMotdParse:
             }
         )
         assert motd.parsed == [
-            # fmt: off
             Formatting.RESET, Formatting.RESET, Formatting.RESET,
             "1",
             Formatting.RESET, Formatting.RESET,
@@ -187,8 +184,7 @@ class TestMotdParse:
             Formatting.RESET, Formatting.RESET,
             "9",
             Formatting.RESET,
-            # fmt: on
-        ]
+        ]  # fmt: skip
 
     def test_raw_attribute(self, source):
         motd = Motd.parse(source)

--- a/tests/status_response/test_java.py
+++ b/tests/status_response/test_java.py
@@ -25,13 +25,16 @@ class TestJavaStatusResponse(BaseStatusResponseTest):
         ("raw", RAW),
         ("forge_data", None),
     ]
-    OPTIONAL_FIELDS = [("favicon", "icon"), ("enforcesSecureChat", "enforces_secure_chat")], {
-        "players": {"max": 20, "online": 0},
-        "version": {"name": "1.8-pre1", "protocol": 44},
-        "description": "A Minecraft Server",
-        "enforcesSecureChat": True,
-        "favicon": "data:image/png;base64,foo",
-    }
+    OPTIONAL_FIELDS = (
+        [("favicon", "icon"), ("enforcesSecureChat", "enforces_secure_chat")],
+        {
+            "players": {"max": 20, "online": 0},
+            "version": {"name": "1.8-pre1", "protocol": 44},
+            "description": "A Minecraft Server",
+            "enforcesSecureChat": True,
+            "favicon": "data:image/png;base64,foo",
+        },
+    )
 
     @pytest.fixture(scope="class")
     def build(self) -> JavaStatusResponse:
@@ -52,15 +55,18 @@ class TestJavaStatusPlayers(BaseStatusResponseTest):
             ],
         ),
     ]
-    OPTIONAL_FIELDS = [("sample", "sample")], {
-        "max": 20,
-        "online": 0,
-        "sample": [
-            {"name": "foo", "id": "0b3717c4-f45d-47c8-b8e2-3d9ff6f93a89"},
-            {"name": "bar", "id": "61699b2e-d327-4a01-9f1e-0ea8c3f06bc6"},
-            {"name": "baz", "id": "40e8d003-8872-412d-b09a-4431a5afcbd4"},
-        ],
-    }
+    OPTIONAL_FIELDS = (
+        [("sample", "sample")],
+        {
+            "max": 20,
+            "online": 0,
+            "sample": [
+                {"name": "foo", "id": "0b3717c4-f45d-47c8-b8e2-3d9ff6f93a89"},
+                {"name": "bar", "id": "61699b2e-d327-4a01-9f1e-0ea8c3f06bc6"},
+                {"name": "baz", "id": "40e8d003-8872-412d-b09a-4431a5afcbd4"},
+            ],
+        },
+    )
 
     @pytest.fixture(scope="class")
     def build(self) -> JavaStatusPlayers:


### PR DESCRIPTION
This replaces both `isort` and `black` with ruff's new tooling.

Ruff contained `isort` support for a while, however it was not entirely compatible with our custom isort rules before. Ruff has made some significant progress, which allows us to now completely replace `isort` with ruff's version of it. The advantage of doing this is obviously one less dependency, but additionally, ruff is also much fater than isort, and the import formatting can now happen during `ruff check` (linter run) through auto-fixes.

More recently (though it was a few months now), ruff has added support for an integrated code formatter, which is intended to replace black. In vast majority of it's formatting rules, it will be the same as black, so there are essentially no changes to the actual code after running `ruff format`. (other than some minor things, like to `#fmt: off` comments, which ruff handles slightly differently, where ruff will only ignore full statements, not individual lines, so these comments had to be moved around a bit, or changed to `# fmt: skip` on the appropriate statement).

This new formatter is much faster than black was, and integrates nicely with our existing ruff configuration.

Lastly, this PR also updates some of ruff's settings/options, as a lot of what we were doing is now deprecated in newer versions of rust (such as setting `select` rules in `[tools.ruff]` instead of `[tools.ruff.lint]`. Or using the `--show-source` CLI argument.