### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+# Cancel already running workflows if new ones are scheduled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validation:
+    uses: ./.github/workflows/validation.yml
+
+  unit-tests:
+    uses: ./.github/workflows/tox-test.yml
+
+  # Produce a pull request payload artifact with various data about the
+  # pull-request event (such as the PR number, title, author, ...).
+  # This data is then be picked up by status-embed.yml action.
+  pr_artifact:
+    name: Produce Pull Request payload artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Prepare Pull Request Payload artifact
+        id: prepare-artifact
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
+
+      - name: Upload a Build Artifact
+        if: always() && steps.prepare-artifact.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: pull-request-payload
+          path: pull_request_payload.json

--- a/.github/workflows/status_embed.yml
+++ b/.github/workflows/status_embed.yml
@@ -3,8 +3,7 @@ name: Status Embed
 on:
   workflow_run:
     workflows:
-      - Validation
-      - Tox test
+      - CI
     types:
       - completed
 
@@ -14,7 +13,7 @@ concurrency:
 
 jobs:
   status_embed:
-    name:  Send Status Embed to Discord
+    name: Send Status Embed to Discord
     runs-on: ubuntu-latest
     steps:
       # A workflow_run event does not contain all the information
@@ -27,13 +26,13 @@ jobs:
           curl -s -H "Authorization: token $GITHUB_TOKEN" ${{ github.event.workflow_run.artifacts_url }} > artifacts.json
           DOWNLOAD_URL=$(cat artifacts.json | jq -r '.artifacts[] | select(.name == "pull-request-payload") | .archive_download_url')
           [ -z "$DOWNLOAD_URL" ] && exit 1
-          wget --quiet --header="Authorization: token $GITHUB_TOKEN" -O pull_request_payload.zip $DOWNLOAD_URL || exit 2
+          curl -sSL -H "Authorization: token $GITHUB_TOKEN" -o pull_request_payload.zip $DOWNLOAD_URL || exit 2
           unzip -p pull_request_payload.zip > pull_request_payload.json
           [ -s pull_request_payload.json ] || exit 3
-          echo "::set-output name=pr_author_login::$(jq -r '.user.login // empty' pull_request_payload.json)"
-          echo "::set-output name=pr_number::$(jq -r '.number // empty' pull_request_payload.json)"
-          echo "::set-output name=pr_title::$(jq -r '.title // empty' pull_request_payload.json)"
-          echo "::set-output name=pr_source::$(jq -r '.head.label // empty' pull_request_payload.json)"
+          echo "pr_author_login=$(jq -r '.user.login // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_number=$(jq -r '.number // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_title=$(jq -r '.title // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_source=$(jq -r '.head.label // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -45,7 +44,7 @@ jobs:
         uses: SebastiaanZ/github-status-embed-for-discord@v0.3.0
         with:
           # Our GitHub Actions webhook
-          webhook_id: '942940470059892796'
+          webhook_id: "942940470059892796"
           webhook_token: ${{ secrets.webhook_token }}
 
           # We need to provide the information of the workflow that
@@ -61,8 +60,3 @@ jobs:
           pr_number: ${{ steps.pr_info.outputs.pr_number }}
           pr_title: ${{ steps.pr_info.outputs.pr_title }}
           pr_source: ${{ steps.pr_info.outputs.pr_source }}
-
-          # And some additional details
-          actor: ${{ github.actor }}
-          repository:  ${{ github.repository }}
-          ref: ${{ github.ref }}

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -1,21 +1,13 @@
 name: Tox test
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-  workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: workflow_call
 
 jobs:
   tox-test:
     runs-on: ${{ matrix.platform }}
 
     strategy:
+      fail-fast: false # Allows for matrix sub-jobs to fail without cancelling the rest
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.12"]
@@ -35,30 +27,24 @@ jobs:
         shell: bash
         run: poetry run tox
         env:
-          PIP_USER: 0  # We want tox to use it's environments, not user installs
+          PIP_USER: 0 # We want tox to use it's environments, not user installs
 
-      # Steps below are here to generate and upload an artifact from
-      # this workflow so that we can have the data about author and some
-      # other things accessible from the status_embed workflow.
+  # This job is used purely to provide a workflow status, which we can mark as a
+  # required action in branch protection rules. This is a better option than marking
+  # the tox-test jobs manually, since their names cnange as the supported python
+  # versions change. This job provides an easy single action that can be marked required.
+  tests-done:
+    needs: [tox-test]
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
 
-      # Prepare the pull request payload artifact. If this fails, we
-      # fail silently using the `continue-on-error` option, since failure
-      # doesn't mean that the checks in this workflow have failed.
-      - name: Prepare Pull Request Payload artifact
-        id: prepare-artifact
-        if: always() && github.event_name == 'pull_request'
-        continue-on-error: true
-        run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
-        shell: bash
-
-      # This only makes sense if the previous step succeeded. To
-      # get the original outcome of the previous step before the
-      # `continue-on-error` conclusion is applied, we use the
-      # `.outcome` value. This step also fails silently.
-      - name: Upload a Build Artifact
-        if: always() && steps.prepare-artifact.outcome == 'success'
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: pull-request-payload
-          path: pull_request_payload.json
+    steps:
+      - name: Set status based on required jobs
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          for result in $RESULTS; do
+            if [ "$result" != "success" ]; then
+              exit 1
+            fi
+          done

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,14 +1,6 @@
 name: Validation
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: workflow_call
 
 env:
   PRE_COMMIT_HOME: "/home/runner/.cache/pre-commit"
@@ -43,35 +35,10 @@ jobs:
         run: SKIP=black,isort,ruff,pyright pre-commit run --all-files
 
       - name: Run ruff linter
-        run: ruff check --output-format=full --show-fixes --exit-non-zero-on-fix .
+        run: ruff check --output-format=github --show-fixes --exit-non-zero-on-fix .
 
       - name: Run ruff formatter
         run: ruff format --diff .
 
       - name: Run pyright type checker
         run: pyright .
-
-      # Steps below are here to generate and upload an artifact from
-      # this workflow so that we can have the data about author and some
-      # other things accessible from the status_embed workflow.
-
-      # Prepare the pull request payload artifact. If this fails, we
-      # fail silently using the `continue-on-error` option, since failure
-      # doesn't mean that the checks in this workflow have failed.
-      - name: Prepare Pull Request Payload artifact
-        id: prepare-artifact
-        if: always() && github.event_name == 'pull_request'
-        continue-on-error: true
-        run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
-
-      # This only makes sense if the previous step succeeded. To
-      # get the original outcome of the previous step before the
-      # `continue-on-error` conclusion is applied, we use the
-      # `.outcome` value. This step also fails silently.
-      - name: Upload a Build Artifact
-        if: always() && steps.prepare-artifact.outcome == 'success'
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: pull-request-payload
-          path: pull_request_payload.json


### PR DESCRIPTION
This PR introduces various changes to the CI workflows in this repository.

**Note:** Once merged, it will be necessary to update the branch proection rules.

Changes:

- Unify the validation and tox-test worfklows under a single CI workflow, which just imports these as individual jobs.
- Only send the status embed once the unified CI workflow finishes (we don't need to see individual statuses for both workflows)
- Use the more up-to-date syntax for setting values in a step output (using `GITHUB_OUTPUT` env var, instead of `::set-output` in stdout)
- Remove needlessly set values in the `SebastiaanZ/github-status-embed-for-discord` action (the action picks these up by default, no need to set them explicitly)
- Disable fast fail for tox-test matrix jobs, allowing the tests to finish on all versions and platforms. (It can be beneficial to see whether this failure only occured in a single python version/platform, or in all versions/platforms).
- Use the `github` output format for `ruff check`, which provides a lot nicer and easier to read formatting of the found issues, suited specifically for github workflows (uses some specific formatting options that github workflows offer to get nice colors, etc.).
- Create a `tests-done` job as a part of the `tox-test` workflow, which will trigger once all of the matrix test jobs ended, reporting the final status (fails if any of the test jobs failed). This is useful as we can specify it in the branch protection rules, instead of specifying all of the individual tox-test jobs in the matrix, which would require updating these rules every time the required python versions/platforms change.

(This PR is inspired by https://github.com/py-mine/mcproto/pull/300)