### PR TITLE
dns: use search suffixes properly

### DIFF
--- a/mcstatus/dns.py
+++ b/mcstatus/dns.py
@@ -19,7 +19,7 @@ def resolve_a_record(hostname: str, lifetime: float | None = None) -> str:
         Most notably this will be :exc:`dns.exception.Timeout`, :exc:`dns.resolver.NXDOMAIN`
         and :exc:`dns.resolver.NoAnswer`
     """
-    answers = dns.resolver.resolve(hostname, RdataType.A, lifetime=lifetime)
+    answers = dns.resolver.resolve(hostname, RdataType.A, lifetime=lifetime, search=True)
     # There should only be one answer here, though in case the server
     # does actually point to multiple IPs, we just pick the first one
     answer = cast(ARecordAnswer, answers[0])
@@ -32,7 +32,7 @@ async def async_resolve_a_record(hostname: str, lifetime: float | None = None) -
 
     For more details, check it.
     """
-    answers = await dns.asyncresolver.resolve(hostname, RdataType.A, lifetime=lifetime)
+    answers = await dns.asyncresolver.resolve(hostname, RdataType.A, lifetime=lifetime, search=True)
     # There should only be one answer here, though in case the server
     # does actually point to multiple IPs, we just pick the first one
     answer = cast(ARecordAnswer, answers[0])
@@ -50,7 +50,7 @@ def resolve_srv_record(query_name: str, lifetime: float | None = None) -> tuple[
         Most notably this will be :exc:`dns.exception.Timeout`, :exc:`dns.resolver.NXDOMAIN`
         and :exc:`dns.resolver.NoAnswer`
     """
-    answers = dns.resolver.resolve(query_name, RdataType.SRV, lifetime=lifetime)
+    answers = dns.resolver.resolve(query_name, RdataType.SRV, lifetime=lifetime, search=True)
     # There should only be one answer here, though in case the server
     # does actually point to multiple IPs, we just pick the first one
     answer = cast(SRVRecordAnswer, answers[0])
@@ -64,7 +64,7 @@ async def async_resolve_srv_record(query_name: str, lifetime: float | None = Non
 
     For more details, check it.
     """
-    answers = await dns.asyncresolver.resolve(query_name, RdataType.SRV, lifetime=lifetime)
+    answers = await dns.asyncresolver.resolve(query_name, RdataType.SRV, lifetime=lifetime, search=True)
     # There should only be one answer here, though in case the server
     # does actually point to multiple IPs, we just pick the first one
     answer = cast(SRVRecordAnswer, answers[0])

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -18,7 +18,7 @@ class TestSRVLookup:
         with patch("dns.resolver.resolve") as resolve:
             resolve.side_effect = [exception]
             address = minecraft_srv_address_lookup("example.org", default_port=25565, lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3)
+            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
 
         assert address.host == "example.org"
         assert address.port == 25565
@@ -31,7 +31,7 @@ class TestSRVLookup:
             resolve.return_value = [answer]
 
             address = minecraft_srv_address_lookup("example.org", lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3)
+            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
         assert address.host == "different.example.org"
         assert address.port == 12345
 
@@ -41,7 +41,7 @@ class TestSRVLookup:
         with patch("dns.asyncresolver.resolve") as resolve:
             resolve.side_effect = [exception]
             address = await async_minecraft_srv_address_lookup("example.org", default_port=25565, lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3)
+            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
 
         assert address.host == "example.org"
         assert address.port == 25565
@@ -55,7 +55,7 @@ class TestSRVLookup:
             resolve.return_value = [answer]
 
             address = await async_minecraft_srv_address_lookup("example.org", lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3)
+            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
         assert address.host == "different.example.org"
         assert address.port == 12345
 
@@ -157,7 +157,7 @@ class TestAddressIPResolving:
 
             resolved_ip = self.host_addr.resolve_ip(lifetime=3)
 
-            resolve.assert_called_once_with(self.host_addr.host, RdataType.A, lifetime=3)
+            resolve.assert_called_once_with(self.host_addr.host, RdataType.A, lifetime=3, search=True)
             assert isinstance(resolved_ip, ipaddress.IPv4Address)
             assert str(resolved_ip) == "48.225.1.104"
 
@@ -170,7 +170,7 @@ class TestAddressIPResolving:
 
             resolved_ip = await self.host_addr.async_resolve_ip(lifetime=3)
 
-            resolve.assert_called_once_with(self.host_addr.host, RdataType.A, lifetime=3)
+            resolve.assert_called_once_with(self.host_addr.host, RdataType.A, lifetime=3, search=True)
             assert isinstance(resolved_ip, ipaddress.IPv4Address)
             assert str(resolved_ip) == "48.225.1.104"
 


### PR DESCRIPTION
DNS resolvers support a list of search domain suffixes, which are appended to hostnames before querying the DNS server. This enables resolving, e.g. internal LAN-only addresses such as http://go/.

Currently, the dns library used by mcstatus fails to do so when using the `query` functionality. This leads to a confusing discrepancy between `status` (which succeeds by using `socket` resolution methods), and `query` which uses the external dnspython.

<details>

```bash-session
[rina@leng mcstatus]$ tail -n4 /etc/resolv.conf
nameserver 127.0.0.53
options edns0 trust-ad
search lan

[rina@leng mcstatus]$ ping pluto
PING pluto.lan (100.89.2.34) 56(84) bytes of data.
64 bytes from pluto.lan (100.89.2.34): icmp_seq=1 ttl=64 time=5.47 ms
64 bytes from pluto.lan (100.89.2.34): icmp_seq=2 ttl=64 time=5.62 ms
^C
--- pluto.siren-koi.ts.net ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 5.466/5.543/5.620/0.077 ms

[rina@leng mcstatus]$ poetry run python -m mcstatus pluto status
version: v1.12.2 (protocol 340)
motd: "Motd(parsed=['', <MinecraftColor.LIGHT_PURPLE: 'd'>, '', <Formatting.ITALIC: 'o'>, 'SevTech: Ages Server', <Formatting.RESET: 'r'>, ' - ', <MinecraftColor.DARK_RED: '4'>, 'v3.2.3', <Formatting.RESET: 'r'>], raw={'text': '§d§oSevTech: Ages Server§r - §4v3.2.3'}, bedrock=False)"
players: 0/20 No players online

[rina@leng mcstatus]$ poetry run python -m mcstatus pluto query
Traceback (most recent call last):
  File "/home/rina/progs/mcstatus/mcstatus/address.py", line 139, in resolve_ip
    ip = ipaddress.ip_address(host)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ipaddress.py", line 54, in ip_address
    raise ValueError(f'{address!r} does not appear to be an IPv4 or IPv6 address')
ValueError: 'pluto' does not appear to be an IPv4 or IPv6 address

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/rina/progs/mcstatus/mcstatus/__main__.py", line 104, in <module>
    main()
  File "/home/rina/progs/mcstatus/mcstatus/__main__.py", line 100, in main
    args.func(server)
  File "/home/rina/progs/mcstatus/mcstatus/__main__.py", line 56, in query
    response = server.query()
               ^^^^^^^^^^^^^^
  File "/home/rina/progs/mcstatus/mcstatus/server.py", line 159, in query
    ip = str(self.address.resolve_ip())
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rina/progs/mcstatus/mcstatus/address.py", line 144, in resolve_ip
    ip_addr = mcstatus.dns.resolve_a_record(self.host, lifetime=lifetime)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rina/progs/mcstatus/mcstatus/dns.py", line 22, in resolve_a_record
    answers = dns.resolver.resolve(hostname, RdataType.A, lifetime=lifetime)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rina/.cache/pypoetry/virtualenvs/mcstatus-txFvW3ui-py3.12/lib/python3.12/site-packages/dns/resolver.py", line 1565, in resolve
    return get_default_resolver().resolve(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rina/.cache/pypoetry/virtualenvs/mcstatus-txFvW3ui-py3.12/lib/python3.12/site-packages/dns/resolver.py", line 1318, in resolve
    (nameserver, tcp, backoff) = resolution.next_nameserver()
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rina/.cache/pypoetry/virtualenvs/mcstatus-txFvW3ui-py3.12/lib/python3.12/site-packages/dns/resolver.py", line 763, in next_nameserver
    raise NoNameservers(request=self.request, errors=self.errors)
dns.resolver.NoNameservers: All nameservers failed to answer the query pluto. IN A: Server Do53:127.0.0.53@53 answered The DNS operation timed out.; Server Do53:127.0.0.53@53 answered REFUSED

[rina@leng mcstatus]$ poetry run python -m mcstatus pluto.lan query
host: 127.0.0.2:25565
software: v1.12.2 vanilla
plugins: []
motd: "Motd(parsed=['', <MinecraftColor.LIGHT_PURPLE: 'd'>, '', <Formatting.ITALIC: 'o'>, 'SevTech: Ages Server', <Formatting.RESET: 'r'>, ' - ', <MinecraftColor.DARK_RED: '4'>, 'v3.2.3'], raw='§d§oSevTech: Ages Server§r - §4v3.2.3', bedrock=False)"
players: 0/20 []
```

</details>

Alternatively, you can also set https://dnspython.readthedocs.io/en/latest/resolver-class.html#dns.resolver.Resolver.use_search_by_default.

Also, just using socket.getaddrinfo would be much simpler.