### PR TITLE
Enable TCP_NODELAY for `TCPAsyncSocketConnection`

### DIFF
--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -609,6 +609,8 @@ class TCPAsyncSocketConnection(BaseAsyncReadSyncWriteConnection):
         """Use :mod:`asyncio` to open a connection to address. Timeout is in seconds."""
         conn = asyncio.open_connection(*self._addr)
         self.reader, self.writer = await asyncio.wait_for(conn, timeout=self.timeout)
+        sock: socket.socket = self.writer.transport.get_extra_info('socket')
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
     async def read(self, length: int) -> bytearray:
         """Read up to ``length`` bytes from :attr:`.reader`."""

--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -609,8 +609,9 @@ class TCPAsyncSocketConnection(BaseAsyncReadSyncWriteConnection):
         """Use :mod:`asyncio` to open a connection to address. Timeout is in seconds."""
         conn = asyncio.open_connection(*self._addr)
         self.reader, self.writer = await asyncio.wait_for(conn, timeout=self.timeout)
-        sock: socket.socket = self.writer.transport.get_extra_info('socket')
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        if self.writer is not None:  # it might be None in unittest
+            sock: socket.socket = self.writer.transport.get_extra_info("socket")
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
     async def read(self, length: int) -> bytearray:
         """Read up to ``length`` bytes from :attr:`.reader`."""


### PR DESCRIPTION
## Motivation

Currently, TCP_NODELAY is enabled in `TCPSocketConnection`

https://github.com/py-mine/mcstatus/blob/d42463f020e5b0d08f794c4bfec517a07bc9c648/mcstatus/protocol/connection.py#L538-L541

but not in `TCPAsyncSocketConnection`

https://github.com/py-mine/mcstatus/blob/d42463f020e5b0d08f794c4bfec517a07bc9c648/mcstatus/protocol/connection.py#L608-L612

As a result, packets sent through the `TCPAsyncSocketConnection` might get delayed, increasing the time cost of `JavaServer.async_ping` or `JavaServer.status` calls. The `latency` result from these 2 methods will also be increased

## The Patch

This PR simply enables TCP_NODELAY after the `asyncio.open_connection` call, just like what `TCPSocketConnection` does

FYI: https://docs.python.org/3/library/asyncio-protocol.html#asyncio.BaseTransport.get_extra_info
