### PR TITLE
Add typing-extensions dep for test uv group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ test = [
   "pytest-cov>=4.1,<7.0",
   "pytest-rerunfailures>=13,<16",
   "coverage>=7.3.0",
+  "typing-extensions>=4.12.2",
 ]
 docs = [
   "sphinx>=7.1.2",

--- a/uv.lock
+++ b/uv.lock
@@ -476,6 +476,7 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-rerunfailures" },
+    { name = "typing-extensions" },
 ]
 
 [package.metadata]
@@ -507,6 +508,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.2,<0.27.0" },
     { name = "pytest-cov", specifier = ">=4.1,<7.0" },
     { name = "pytest-rerunfailures", specifier = ">=13,<16" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
Currenlty the `typing-extensions` dependency was only getting installed for the lint group, however, when we run tests in the CI, the lint group doesn't get installed, which causes a runtime error.

This could also be solved by using the `TYPE_CHECKING` block in unit-tests code, but I think this is a simpler option, as we don't really need to care about our development-only code not introducing typing-extensions as runtime dep.