### PR TITLE
Fix ruff & revert 997

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,9 +59,7 @@ BEDROCK_RAW_RESPONSE = [
 EXPECTED_HELP_OUTPUT = """
 usage: mcstatus [-h] [--bedrock] address {ping,status,query,json} ...
 
-mcstatus provides an easy way to query 1.7 or newer Minecraft servers for any
-information they can expose. It provides three modes of access: query, status,
-ping and json.
+mcstatus provides an easy way to query Minecraft servers for any information they can expose. It provides three modes of access: query, status, ping and json.
 
 positional arguments:
   address               The address of the server.
@@ -75,9 +73,9 @@ commands:
 
   {ping,status,query,json}
     ping                Ping server for latency.
-    status              Prints server status.
+    status              Prints server status. Supported by all Minecraft servers that are version 1.7 or higher.
     query               Prints detailed server information. Must be enabled in servers' server.properties file.
-    json                Prints server status and query in json.
+    json                Prints server status and query in json. Supported by all Minecraft servers that are version 1.7 or higher.
 """  # noqa: E501(line length)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,7 +76,7 @@ commands:
     status              Prints server status. Supported by all Minecraft servers that are version 1.7 or higher.
     query               Prints detailed server information. Must be enabled in servers' server.properties file.
     json                Prints server status and query in json. Supported by all Minecraft servers that are version 1.7 or higher.
-"""  # noqa: E501(line length)
+"""  # noqa: E501 (line length)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This reverts py-mine/mcstatus#997, and instead fixes the relevant noqa to pass ruff properly. See [this remark](https://github.com/py-mine/mcstatus/pull/997#issuecomment-2864596648) for more info.

@kevinkjt2000 I will note that this is a simple revert of your PR + the noqa fix, nothing more. If you wish to introduce the formatting change to help command output, which I did think was an improvement, you can do so in another PR.

(Also, woo, PR 1000)