### PR TITLE
Fix typo in bot username in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Devops & CI workflows
-.github/dependabot.yml      @ItsDrike @py-mine-ci-bot
-.github/workflows/**        @ItsDrike @py-mine-ci-bot
+.github/dependabot.yml      @ItsDrike
+.github/workflows/**        @ItsDrike
 .pre-commit-config.yaml     @ItsDrike

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Devops & CI workflows
-.github/dependabot.yml      @ItsDrike @py-mine-bot
-.github/workflows/**        @ItsDrike @py-mine-bot
+.github/dependabot.yml      @ItsDrike @py-mine-ci-bot
+.github/workflows/**        @ItsDrike @py-mine-ci-bot
 .pre-commit-config.yaml     @ItsDrike


### PR DESCRIPTION
In #998, the pymine bot account was added as a code-owner to simplify the approval process for auto-bump PRs. However, I accidentally suggested using the wrong bot account, as we have both @py-mine-bot (which we used for migrating old issues) and @py-mine-ci-bot application which is what we actually want here.

![image](https://github.com/user-attachments/assets/75739f56-46d7-4bb5-b799-0acf395dd9a6)
