### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ env:
   PYTHON_VERSION: "3.13"
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This fixes a typo in the job name for the publish workflow.

Once merged, the v12 tag can be force recreated, to re-trigger the workflow, or we can publish manually and leave the workflow for the next release.
