### PR TITLE
Use query_port in async_query() calls

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -196,7 +196,7 @@ class JavaServer(MCServer):
         :return: Query information in a :class:`~mcstatus.querier.QueryResponse` instance.
         """
         ip = str(await self.address.async_resolve_ip())
-        return await self._retry_async_query(Address(ip, self.address.port), tries=tries)
+        return await self._retry_async_query(Address(ip, self.query_port), tries=tries)
 
     @retry(tries=3)
     async def _retry_async_query(self, address: Address, **_kwargs) -> QueryResponse:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -100,6 +100,15 @@ def test_java_server_with_query_port():
         assert patched_query_func.call_args == call(Address("127.0.0.1", port=12345), tries=3)
 
 
+@pytest.mark.asyncio
+async def test_java_server_with_query_port_async():
+    with patch("mcstatus.server.JavaServer._retry_async_query") as patched_query_func:
+        server = JavaServer("localhost", query_port=12345)
+        await server.async_query()
+        assert server.query_port == 12345
+        assert patched_query_func.call_args == call(Address("127.0.0.1", port=12345), tries=3)
+
+
 class TestJavaServer:
     def setup_method(self):
         self.socket = Connection()


### PR DESCRIPTION
Primarily referring to commit https://github.com/py-mine/mcstatus/commit/8202888d3c63084dfc77f3690cc48ff468d3afcd.

## Changes
Currently, `query()` makes use of the `query_port` value, but `async_query()` does not.
```python
return await self._retry_async_query(Address(ip, self.address.port), tries=tries)
```

This PR introduces a small change to ensure that `async_query()` also utilizes the `query_port` value, making the behavior consistent with `query()`.

## Reasoning
The change ensures that the `async_query()` function behaves in a similar manner to `query()`. This should prevent potential issues for users who rely on the `query_port` value for their queries.

## Tests
No additional tests should be needed, as the existing tests already cover the relevant scenarios. If further clarification or adjustments are required, I'd be happy to add them.