### PR TITLE
Don't use deprecated properties in our CLI

### DIFF
--- a/mcstatus/__main__.py
+++ b/mcstatus/__main__.py
@@ -132,7 +132,7 @@ def json_cmd(server: SupportedServers) -> int:
 
         qdata["ip"] = query_res.raw["hostip"]
         qdata["port"] = query_res.raw["hostport"]
-        qdata["map"] = query_res.map
+        qdata["map"] = query_res.map_name
         qdata["plugins"] = query_res.software.plugins
         qdata["raw"] = query_res.raw
 
@@ -155,7 +155,7 @@ def query_cmd(server: SupportedServers) -> int:
     print(f"software: {_kind(server)} {response.software.version} {response.software.brand}")
     print(f"motd:{_motd(response.motd)}")
     print(f"plugins: {response.software.plugins}")
-    print(f"players: {response.players.online}/{response.players.max} {response.players.names}")
+    print(f"players: {response.players.online}/{response.players.max} {response.players.list}")
     return 0
 
 


### PR DESCRIPTION
This fixes these warnings that are raised during tests:

```py
tests/test_cli.py::test_query
  /home/perchun/dev/mcstatus/mcstatus/__main__.py:158:
  DeprecationWarning: 'QueryPlayers.names' is deprecated and is expected
  to be removed on 2025-12, use ''list' attribute' instead.
    print(f"players: {response.players.online}/{response.players.max} {response.players.names}")

tests/test_cli.py::test_json
  /home/perchun/dev/mcstatus/mcstatus/__main__.py:135:
  DeprecationWarning: 'QueryResponse.map' is deprecated and is expected
  to be removed on 2025-12, use 'map_name' instead.
    qdata["map"] = query_res.map
```