### PR TITLE
Set `asyncio_default_fixture_loop` in pytest config to fix warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,9 @@ minversion = "6.0"
 addopts = "--strict-markers --doctest-modules --cov=mcstatus --cov-append --cov-branch --cov-report=term-missing -vvv --no-cov-on-fail --asyncio-mode=strict"
 testpaths = ["tests"]
 
+# Remove deprecation warning
+asyncio_default_fixture_loop_scope = "function"
+
 [tool.pyright]
 pythonPlatform = "All"
 pythonVersion = "3.9"


### PR DESCRIPTION
```py
/home/perchun/dev/mcstatus/.venv/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208:
  PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.

  The event loop scope for asynchronous fixtures will default to the
  fixture caching scope. Future versions of pytest-asyncio will default
  the loop scope for asynchronous fixtures to function scope. Set the
  default fixture loop scope explicitly in order to avoid unexpected
  behavior in the future. Valid fixture loop scopes are: "function",
  "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
```