### PR TITLE
Move `typing_extensions` to `typing.TYPE_CHECKING` block in __main__.py

### DIFF
--- a/mcstatus/__main__.py
+++ b/mcstatus/__main__.py
@@ -7,13 +7,14 @@ import argparse
 import socket
 import dataclasses
 from typing import TYPE_CHECKING
-from typing_extensions import TypeAlias
 
 from mcstatus import JavaServer, BedrockServer
 from mcstatus.responses import JavaStatusResponse
 from mcstatus.motd import Motd
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     SupportedServers: TypeAlias = "JavaServer | BedrockServer"
 
 PING_PACKET_FAIL_WARNING = (


### PR DESCRIPTION
Fixes #1017