### PR TITLE
Bump version to v12.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcstatus"
-version = "12.0.1"
+version = "12.0.2"
 license = "Apache-2.0"
 description = "A library to query Minecraft Servers for their status and capabilities."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "mcstatus"
-version = "12.0.0"
+version = "12.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "asyncio-dgram" },


### PR DESCRIPTION
**Should be merged only after #1018**

```md
## What's Changed
* Move `typing_extensions` to `typing.TYPE_CHECKING` block in __main__.py by @PerchunPak in https://github.com/py-mine/mcstatus/pull/1018
  This fixes our CLI, see https://github.com/py-mine/mcstatus/issues/1017

**Full Changelog**: https://github.com/py-mine/mcstatus/compare/v12.0.1...v12.0.2
```