### PR TITLE
Ban `typing_extensions` at module level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ ignore = [
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
+banned-module-level-imports = ["typing_extensions"]
 
 [tool.ruff.lint.isort]
 order-by-type = false


### PR DESCRIPTION
It is allowed only in `typing.TYPE_CHECKING` block

Prevents https://github.com/py-mine/mcstatus/issues/1017 in the future
See also https://github.com/astral-sh/ruff/issues/18885