### PR TITLE
Add mcstatus cli to project scripts 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,3 +189,6 @@ line-ending = "lf"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.scripts]
+mcstatus = "mcstatus.__main__:main"


### PR DESCRIPTION
Basically what it says in the title. This change defines `mcstatus` as an available package executable in `pyproject.toml`. Currently when you try to run mcstatus using `uvx` or `pipx` you'll get an error like the following:

```bash
❯ uvx mcstatus
Package `mcstatus` does not provide any executables.
```

This is simple addition to allow these tools to run the cli.