### PR TITLE
Update wiki.vg refs to minecraft.wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Validation](https://github.com/py-mine/mcstatus/actions/workflows/validation.yml/badge.svg)](https://github.com/py-mine/mcstatus/actions/workflows/validation.yml)
 [![Unit Tests](https://github.com/py-mine/mcstatus/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/py-mine/mcstatus/actions/workflows/unit-tests.yml)
 
-Mcstatus provides an API and command line script to fetch publicly available data from Minecraft servers. Specifically, mcstatus retrieves data by using these protocols: [Server List Ping](https://wiki.vg/Server_List_Ping) and [Query](https://wiki.vg/Query). Because of mcstatus, you do not need to fully understand those protocols and can instead skip straight to retrieving minecraft server data quickly in your own programs.
+Mcstatus provides an API and command line script to fetch publicly available data from Minecraft servers. Specifically, mcstatus retrieves data by using these protocols: [Server List Ping](https://minecraft.wiki/w/Java_Edition_protocol/Server_List_Ping) and [Query](https://minecraft.wiki/w/Query). Because of mcstatus, you do not need to fully understand those protocols and can instead skip straight to retrieving minecraft server data quickly in your own programs.
 
 ## Installation
 

--- a/mcstatus/__main__.py
+++ b/mcstatus/__main__.py
@@ -28,7 +28,7 @@ QUERY_FAIL_WARNING = (
     "The server did not respond to the query protocol."
     "\nPlease ensure that the server has enable-query turned on,"
     " and that the necessary port (same as server-port unless query-port is set) is open in any firewall(s)."
-    "\nSee https://wiki.vg/Query for further information."
+    "\nSee https://minecraft.wiki/w/Query for further information."
 )
 
 

--- a/mcstatus/bedrock_status.py
+++ b/mcstatus/bedrock_status.py
@@ -13,7 +13,7 @@ from mcstatus.responses import BedrockStatusResponse
 
 class BedrockServerStatus:
     request_status_data = bytes.fromhex(
-        # see https://wiki.vg/Raknet_Protocol#Unconnected_Ping
+        # see https://minecraft.wiki/w/RakNet#Unconnected_Ping
         "01" + "0000000000000000" + "00ffff00fefefefefdfdfdfd12345678" + "0000000000000000"
     )
 

--- a/mcstatus/motd/__init__.py
+++ b/mcstatus/motd/__init__.py
@@ -159,7 +159,8 @@ class Motd:
                 # a formatting, and it resets both color and other formatting, so we use
                 # `Formatting.RESET` here.
                 #
-                # see https://wiki.vg/Chat#Shared_between_all_components, `color` field
+                # see `color` field in
+                # https://minecraft.wiki/w/Java_Edition_protocol/Chat?oldid=2763811#Shared_between_all_components
                 return Formatting.RESET
 
             # Last attempt: try parsing as HTML (hex rgb) color. Some servers use these to

--- a/tests/motd/test_motd.py
+++ b/tests/motd/test_motd.py
@@ -65,7 +65,7 @@ class TestMotdParse:
         assert Motd.parse(input).parsed == expected
 
     def test_top_level_formatting_applies_to_all_in_extra(self) -> None:
-        """As described `here <https://wiki.vg/Chat#Inheritance>`_."""
+        """As described `here <https://minecraft.wiki/w/Java_Edition_protocol/Chat?direction=prev&oldid=2763844#Inheritance>`_."""
         assert Motd.parse({"text": "top", "bold": True, "extra": [{"color": "red", "text": "not top"}]}).parsed == [
             Formatting.BOLD,
             "top",
@@ -77,7 +77,7 @@ class TestMotdParse:
         ]
 
     def test_top_level_formatting_can_be_overwrote(self) -> None:
-        """As described `here <https://wiki.vg/Chat#Inheritance>`_."""
+        """As described `here <https://minecraft.wiki/w/Java_Edition_protocol/Chat?direction=prev&oldid=2763844#Inheritance>`_."""
         assert Motd.parse(
             {"text": "bold", "bold": True, "extra": [{"color": "red", "bold": False, "text": "not bold"}]}
         ).parsed == [


### PR DESCRIPTION
This changes all references to the no longer working https://wiki.vg site to point to https://minecraft.wiki (for certain links, I had to use an older version of the page, as the new content differs, this mainly applies to the motd handling)