### PR TITLE
Publish Test PyPI releases on every commit to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
-name: Publish to PyPi
+---
+name: Publish to PyPI
 
 on:
   push:
@@ -6,12 +7,10 @@ on:
       # This pattern is not a typical regular expression, see:
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       - "v*"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: Git Tag to use for the release
-        required: true
-        type: string
+    branches:
+      # Also run on every commit to main. This allows us to test the build & release pipeline and eventually leads to a
+      # Test PyPI release. Unlike with a tag push, this will not release a full PyPI release, nor create a GitHub release.
+      - main
 
 permissions:
   contents: read
@@ -21,41 +20,56 @@ env:
 
 jobs:
   build:
+    name: "Build the project"
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Get Tag
-        id: get_tag
-        run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            # For push events, the tag is in GITHUB_REF
-            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # For workflow_dispatch, the tag is in the input
-            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          fi
+    outputs:
+      version: ${{ steps.check-version.outputs.version }}
+      tagged_release: ${{ steps.check-version.outputs.tagged_release }}
 
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Checkout the specific tag
-          ref: ${{ steps.get_tag.outputs.tag }}
+          # Do a full clone for uv-dynamic-versioning to pick up the git version
+          fetch-depth: 0
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
         with:
           version: "latest"
           python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
-          cache-suffix: "publish-ci"
           activate-environment: true
+          enable-cache: true
+          cache-suffix: "build"
 
       - name: Install dependencies
         run: |
-          uv sync --no-default-groups
+          uv sync --no-default-groups --group release
 
-      - name: Build package
-        run: uv build
+      - name: Check version status
+        id: check-version
+        run: |
+          version="$(hatchling version)"
+
+          echo "Project version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          # Determine whether we're doing a tagged release e.g. this workflow
+          # was triggered by a git tag ref that matches the project's current
+          # version, so a full PyPI release should be made, alongside all of
+          # the other release steps. If this isn't the case, only a Test PyPI
+          # release will be performed.
+          if [[ "${GITHUB_REF}" == "refs/tags/v${version}" ]]; then
+            echo "This is a new tagged release"
+            echo "tagged_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "This is an untagged dev release"
+            echo "tagged_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build project for distribution
+        run: uv build --all-packages
 
       - name: Upload build files
         uses: actions/upload-artifact@v4
@@ -65,22 +79,48 @@ jobs:
           if-no-files-found: error
           retention-days: 5
 
-  publish-pypi:
-    name: "Publish to PyPI"
+  publish-test-pypi:
+    name: "Publish to Test PyPI"
+    # No if condition here, publish both tagged and untagged releases to Test PyPI.
     needs: build
     runs-on: ubuntu-latest
-    environment: release
+    environment: test-pypi # no approval
+    permissions:
+      # Used to authenticate to Test PyPI via OIDC.
+      id-token: write
+
+    steps:
+      - name: Download the distribution files from build artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: "dist"
+          path: "dist/"
+
+      - name: Upload to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # the "legacy" in the URL doesn't mean it's deprecated
+          repository-url: https://test.pypi.org/legacy/
+          # Enable verbose mode for easy debugging
+          verbose: true
+
+  publish-pypi:
+    name: "Publish to PyPI"
+    if: needs.build.outputs.tagged_release == 'true' # only publish to PyPI on tagged releases
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release # requires approval
     permissions:
       # Used to authenticate to PyPI via OIDC.
       id-token: write
 
     steps:
-      - name: Download the distribution files from PR artifact
+      - name: Download the distribution files from build artifact
         uses: actions/download-artifact@v5
         with:
           name: "dist"
           path: "dist/"
 
       # This uses PyPI's trusted publishing, so no token is required
-      - name: Publish package distributions to PyPI
+      - name: Release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ docs = [
   "uv-dynamic-versioning", # actual version is in `release` group
 ]
 release = [
+  "hatchling>=1.27.0",
   "uv-dynamic-versioning>=0.8.2",
 ]
 
@@ -199,3 +200,4 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"
+metadata = false

--- a/uv.lock
+++ b/uv.lock
@@ -530,6 +530,7 @@ lint = [
     { name = "typing-extensions" },
 ]
 release = [
+    { name = "hatchling" },
     { name = "uv-dynamic-versioning" },
 ]
 test = [
@@ -565,7 +566,10 @@ lint = [
     { name = "ruff", specifier = ">=0.11.2" },
     { name = "typing-extensions", specifier = ">=4.7.1" },
 ]
-release = [{ name = "uv-dynamic-versioning", specifier = ">=0.8.2" }]
+release = [
+    { name = "hatchling", specifier = ">=1.27.0" },
+    { name = "uv-dynamic-versioning", specifier = ">=0.8.2" },
+]
 test = [
     { name = "coverage", specifier = ">=7.3.0" },
     { name = "pytest", specifier = ">=7.4,<9.0" },


### PR DESCRIPTION
This modifies the `publish.yml` workflow to run with every commit to `main` branch. These commits will then lead to producing a Test PyPI release.

That way, we will get to test out our publishing CI constantly, so that when we do want to push out a release, we don't need to be afraid that it might not work since the CI was modified and this is the first time it's running.

Additionally, it will give our users the option to use these TestPyPI releases if they want a more up-to-date version of the library, without having to result to directly using git and building the package locally. This also gives users the benefit of having checkable attestations, proving that the build files were produced by our CI on the TestPyPI.

Note 1: This modifies `uv-dynamic-versioning` to avoid including the commit sha as the local version component (e.g. instead of `0.6.0.post10.dev0+81baa11`, only produce `0.6.0.post10.dev0`). This is because PyPI [doesn't support](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers) the use of local version components.

Note 2: This drops support for the `workflow_call` trigger, if still we really want it, I should be able to integrate it with this, though I'm not sure how necessary it is.

PS: See the Test PyPI installation instructions in [mcproto docs](https://py-mine.github.io/mcproto/latest/installation/#test-pypi-latest-main-commit-builds)
