### PR TITLE
Disable metadata for uv-dynamic-versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,4 +200,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
 metadata = false


### PR DESCRIPTION
This fixes the publish CI issue that's currently occurring in `master` after #1042 and #1043 were merged. This is because I accidentally set the `metadata = false` setting under the `tool.hatch.version` rather than under the `tool.uv-dynamic-versioning`, which meant the metadata info wasn't being removed from the version, leading to Test PyPI refusing the upload due to invalid version.
