### PR TITLE
Update renamed label names in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,11 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "area: dependencies"
+      - "a: dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     labels:
-      - "area: dependencies"
+      - "a: dependencies"


### PR DESCRIPTION
This updates the dependabot configuration label names to match the labels configured for the repository.

(I have changed the labels, simplifying them from area: X to just a: X; I made the same change for all label categories, though for dependabot, only the area one is relevant)