### PR TITLE
Replace deprecated asyncio.iscoroutinefunction

### DIFF
--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 import warnings
 from collections.abc import Callable, Iterable
@@ -68,7 +67,7 @@ def retry(tries: int, exceptions: tuple[type[BaseException]] = (Exception,)) -> 
 
         # We cast here since pythons typing doesn't support adding keyword-only arguments to signature
         # (Support for this was a rejected idea https://peps.python.org/pep-0612/#concatenating-keyword-parameters)
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             return cast("Callable[P, R]", async_wrapper)
         return cast("Callable[P, R]", sync_wrapper)
 


### PR DESCRIPTION
## Summary
Python 3.14 will deprecated `asyncio.iscoroutinefunction` in favor of `inspect.iscoroutinefunction` which has been available for some time now.

https://docs.python.org/3.14/deprecations/pending-removal-in-3.16.html
https://docs.python.org/3.14/library/inspect.html#inspect.iscoroutinefunction