### PR TITLE
Specify dependency versions using `~=` instead of `>=`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,34 +43,33 @@ Documentation = "https://mcstatus.readthedocs.io"
 default-groups = ["dev", "lint", "test", "docs"]
 
 [dependency-groups]
-dev = ["poethepoet>=0.32.1"]
+dev = ["poethepoet~=0.36.0"]
 lint = [
-  "pre-commit>=3.3.3",
-  "ruff>=0.11.2",
-  "pyright>=1.1.322",
-  "typing-extensions>=4.7.1",
+  "pre-commit~=4.0.1",
+  "ruff~=0.12.7",
+  "pyright==1.1.403",
+  "typing-extensions~=4.14.1",
 ]
 test = [
-  "pytest>=7.4,<9.0",
-  "pytest-asyncio>=0.23.2,<0.27.0",
-  "pytest-cov>=4.1,<7.0",
-  "pytest-rerunfailures>=13,<16",
-  "coverage>=7.3.0",
-  "typing-extensions>=4.12.2",
+  "pytest~=8.4.1",
+  "pytest-asyncio~=0.24.0",
+  "pytest-cov~=6.2.1",
+  "pytest-rerunfailures~=15.1",
+  "coverage~=7.6.10",
+  "typing-extensions~=4.14.1",
 ]
 docs = [
-  "sphinx>=7.1.2",
-  "sphinx-autodoc-typehints>=1.24,<3.0",
-  "furo>=2022.12.7",
-  "m2r2>=0.3.3",
-  "tomli>=2.0.1; python_version < '3.11'",
-  "packaging>=24.2",
-  "docutils>=0.18.1,<0.21", # temporary fix for https://github.com/CrossNox/m2r2/issues/68
+  "sphinx~=8.1.3",
+  "sphinx-autodoc-typehints~=2.5.0",
+  "furo>=2025.7.19",
+  "m2r2~=0.3.4",
+  "tomli~=2.2.1; python_version < '3.11'",
+  "packaging~=25.0",
   "uv-dynamic-versioning", # actual version is in `release` group
 ]
 release = [
-  "hatchling>=1.27.0",
-  "uv-dynamic-versioning>=0.8.2",
+  "hatchling~=1.27.0",
+  "uv-dynamic-versioning~=0.8.2",
 ]
 
 [tool.poe.tasks]

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,6 @@ dev = [
     { name = "poethepoet" },
 ]
 docs = [
-    { name = "docutils" },
     { name = "furo" },
     { name = "m2r2" },
     { name = "packaging" },
@@ -473,34 +472,33 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "poethepoet", specifier = ">=0.32.1" }]
+dev = [{ name = "poethepoet", specifier = "~=0.36.0" }]
 docs = [
-    { name = "docutils", specifier = ">=0.18.1,<0.21" },
-    { name = "furo", specifier = ">=2022.12.7" },
-    { name = "m2r2", specifier = ">=0.3.3" },
-    { name = "packaging", specifier = ">=24.2" },
-    { name = "sphinx", specifier = ">=7.1.2" },
-    { name = "sphinx-autodoc-typehints", specifier = ">=1.24,<3.0" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
+    { name = "furo", specifier = ">=2025.7.19" },
+    { name = "m2r2", specifier = "~=0.3.4" },
+    { name = "packaging", specifier = "~=25.0" },
+    { name = "sphinx", specifier = "~=8.1.3" },
+    { name = "sphinx-autodoc-typehints", specifier = "~=2.5.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = "~=2.2.1" },
     { name = "uv-dynamic-versioning" },
 ]
 lint = [
-    { name = "pre-commit", specifier = ">=3.3.3" },
-    { name = "pyright", specifier = ">=1.1.322" },
-    { name = "ruff", specifier = ">=0.11.2" },
-    { name = "typing-extensions", specifier = ">=4.7.1" },
+    { name = "pre-commit", specifier = "~=4.0.1" },
+    { name = "pyright", specifier = "==1.1.403" },
+    { name = "ruff", specifier = "~=0.12.7" },
+    { name = "typing-extensions", specifier = "~=4.14.1" },
 ]
 release = [
-    { name = "hatchling", specifier = ">=1.27.0" },
-    { name = "uv-dynamic-versioning", specifier = ">=0.8.2" },
+    { name = "hatchling", specifier = "~=1.27.0" },
+    { name = "uv-dynamic-versioning", specifier = "~=0.8.2" },
 ]
 test = [
-    { name = "coverage", specifier = ">=7.3.0" },
-    { name = "pytest", specifier = ">=7.4,<9.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23.2,<0.27.0" },
-    { name = "pytest-cov", specifier = ">=4.1,<7.0" },
-    { name = "pytest-rerunfailures", specifier = ">=13,<16" },
-    { name = "typing-extensions", specifier = ">=4.12.2" },
+    { name = "coverage", specifier = "~=7.6.10" },
+    { name = "pytest", specifier = "~=8.4.1" },
+    { name = "pytest-asyncio", specifier = "~=0.24.0" },
+    { name = "pytest-cov", specifier = "~=6.2.1" },
+    { name = "pytest-rerunfailures", specifier = "~=15.1" },
+    { name = "typing-extensions", specifier = "~=4.14.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
`~= 1.2.3` is the same as `== 1.2.*`. This sets all of the versions to what we actually have in uv.lock. Generated using this script

```py
import json
import subprocess

import tomllib
from packaging.requirements import Requirement


def get_current_versions() -> dict[str, str]:
    result = {}
    unparsed = json.loads(subprocess.check_output(["uv", "pip", "list", "--format", "json"]))
    for dep in unparsed:
        result[dep["name"]] = dep["version"]
    return result


current_versions = get_current_versions()
with open("pyproject.toml", "rb") as f:
    pyproject = tomllib.load(f)

# stdlib tomllib can't write toml files for some reason
# so we have to manually print instead
for group_name, dependencies in pyproject["dependency-groups"].items():
    print(f"{group_name} = [")
    for dependency in dependencies:
        parsed_dep = Requirement(dependency)
        try:
            version = current_versions[parsed_dep.name]
        except KeyError:
            if parsed_dep.name == "tomli":
                version = "2.2.1"
            else:
                raise ValueError(f"Could not find current package version for {parsed_dep}")

        print(f'  "{parsed_dep.name}~={version}",')
    print("]")
```

Let's hope dependabot won't mess it up...