### PR TITLE
Add `fallback-version` for `uv-dynamic-versioning`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,3 +201,4 @@ source = "uv-dynamic-versioning"
 
 [tool.uv-dynamic-versioning]
 metadata = false
+fallback-version = "0.0.0"


### PR DESCRIPTION
Dependabot fails because it cannot resolve version. See also https://github.com/ninoseki/uv-dynamic-versioning/issues/27 and https://github.com/py-mine/mcstatus/network/updates/1202317077