### PR TITLE
HTML MOTD transformer: replace new lines with `<br>`

### DIFF
--- a/mcstatus/motd/transformers.py
+++ b/mcstatus/motd/transformers.py
@@ -147,6 +147,9 @@ class HtmlTransformer(PlainTransformer):
     def _format_output(self, results: list[str]) -> str:
         return "<p>" + super()._format_output(results) + "".join(self.on_reset) + "</p>"
 
+    def _handle_str(self, element: str, /) -> str:
+        return element.replace("\n", "<br>")
+
     def _handle_minecraft_color(self, element: MinecraftColor, /) -> str:
         color_map = self.MINECRAFT_COLOR_TO_RGB_BEDROCK if self.bedrock else self.MINECRAFT_COLOR_TO_RGB_JAVA
         fg_color, bg_color = color_map[element]

--- a/tests/motd/test_transformers.py
+++ b/tests/motd/test_transformers.py
@@ -86,6 +86,10 @@ class TestMotdHTML:
             "21</p>"
         )
 
+    def test_new_line_is_br_tag(self):
+        motd = Motd.parse("Some cool\ntext")
+        assert motd.to_html() == "<p>Some cool<br>text</p>"
+
 
 class TestMotdAnsi:
     @pytest.fixture(scope="class", params=[True, False])


### PR DESCRIPTION
Fixes one of the bugs mentioned in https://github.com/py-mine/mcstatus/issues/1093