### PR TITLE
Use versions instead of dates in deprecation messages

### DIFF
--- a/mcstatus/responses.py
+++ b/mcstatus/responses.py
@@ -407,11 +407,11 @@ class BedrockStatusVersion(BaseStatusVersion):
     """``MCPE`` or ``MCEE`` for Education Edition."""
 
     @property
-    @deprecated(replacement="name", date="2025-12")
+    @deprecated(replacement="name", version="13.0.0")
     def version(self) -> str:
         """
         .. deprecated:: 12.0.0
-            Will be removed 2025-12, use :attr:`.name` instead.
+            Will be removed in 13.0.0, use :attr:`.name` instead.
         """
         return self.name
 
@@ -481,11 +481,11 @@ class QueryResponse:
         return as_dict
 
     @property
-    @deprecated(replacement="map_name", date="2025-12")
+    @deprecated(replacement="map_name", version="13.0.0")
     def map(self) -> str | None:
         """
         .. deprecated:: 12.0.0
-            Will be removed 2025-12, use :attr:`.map_name` instead.
+            Will be removed in 13.0.0, use :attr:`.map_name` instead.
         """
         return self.map_name
 
@@ -510,11 +510,11 @@ class QueryPlayers:
         )
 
     @property
-    @deprecated(replacement="'list' attribute", date="2025-12")
+    @deprecated(replacement="'list' attribute", version="13.0.0")
     def names(self) -> list[str]:
         """
         .. deprecated:: 12.0.0
-            Will be removed 2025-12, use :attr:`.list` instead.
+            Will be removed in 13.0.0, use :attr:`.list` instead.
         """
         return self.list
 

--- a/mcstatus/status_response.py
+++ b/mcstatus/status_response.py
@@ -29,7 +29,7 @@ __all__ = [
 import warnings
 
 warnings.warn(
-    "`mcstatus.status_response` is deprecated, and will be removed at 2025-12, use `mcstatus.responses` instead",
+    "`mcstatus.status_response` is deprecated, and will be removed in 13.0.0, use `mcstatus.responses` instead",
     DeprecationWarning,
     stacklevel=2,
 )


### PR DESCRIPTION
I am not sure if we intend to release a major release soon, so using dates from the past is confusing.