### PR TITLE
CLI: improve how player sample is displayed

### DIFF
--- a/mcstatus/__main__.py
+++ b/mcstatus/__main__.py
@@ -82,12 +82,10 @@ def status_cmd(server: SupportedServers) -> int:
 
     java_res = response if isinstance(response, JavaStatusResponse) else None
 
-    if not java_res:
-        player_sample = ""
-    elif java_res.players.sample is not None:
+    if java_res and java_res.players.sample:
         player_sample = "\n  " + "\n  ".join(f"{player.name} ({player.id})" for player in java_res.players.sample)
     else:
-        player_sample = " No players online"
+        player_sample = ""
 
     print(f"version: {_kind(server)} {response.version.name} (protocol {response.version.protocol})")
     print(f"motd:{_motd(response.motd)}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,9 +168,9 @@ def test_one_argument_is_status(mock_network_requests):
     assert out.getvalue() == (
         "version: Java 1.8-pre1 (protocol 44)\n"
         "motd: \x1b[0mA Minecraft Server\x1b[0m\n"
-        "players: 0/20 No players online\n"
+        "players: 0/20\n"
         "ping: 0.00 ms\n"
-    )
+    )  # fmt: skip
     assert err.getvalue() == ""
 
 
@@ -181,13 +181,13 @@ def test_status(mock_network_requests):
     assert out.getvalue() == (
         "version: Java 1.8-pre1 (protocol 44)\n"
         "motd: \x1b[0mA Minecraft Server\x1b[0m\n"
-        "players: 0/20 No players online\n"
+        "players: 0/20\n"
         "ping: 0.00 ms\n"
-    )
+    )  # fmt: skip
     assert err.getvalue() == ""
 
 
-def test_status_no_sample(mock_network_requests):
+def test_status_with_sample(mock_network_requests):
     raw_response = JAVA_RAW_RESPONSE.copy()
     raw_response["players"] = JAVA_RAW_RESPONSE["players"].copy()
     raw_response["players"]["sample"] = [
@@ -211,6 +211,26 @@ def test_status_no_sample(mock_network_requests):
         "  baz (7edb3b2e-869c-485b-af70-76a934e0fcfd)\n"
         "ping: 0.00 ms\n"
     )
+    assert err.getvalue() == ""
+
+
+def test_status_sample_empty_list(mock_network_requests):
+    raw_response = JAVA_RAW_RESPONSE.copy()
+    raw_response["players"] = JAVA_RAW_RESPONSE["players"].copy()
+    raw_response["players"]["sample"] = []
+
+    with (
+        patch("mcstatus.server.JavaServer.status", return_value=JavaStatusResponse.build(raw_response)),
+        patch_stdout_stderr() as (out, err),
+    ):
+        assert main_under_test(["example.com", "status"]) == 0
+
+    assert out.getvalue() == (
+        "version: Java 1.8-pre1 (protocol 44)\n"
+        "motd: \x1b[0mA Minecraft Server\x1b[0m\n"
+        "players: 0/20\n"
+        "ping: 0.00 ms\n"
+    )  # fmt: skip
     assert err.getvalue() == ""
 
 


### PR DESCRIPTION
Was

```
version: Java 1.8-pre1 (protocol 44)
motd: A Minecraft Server
players: 0/20 ['foo (497dcba3-ecbf-4587-a2dd-5eb0665e6880)', 'bar (50e14f43-dd4e-412f-864d-78943ea28d91)', 'baz (7edb3b2e-869c-485b-af70-76a934e0fcfd)']
ping: 0.00 ms
```

Now

```
version: Java 1.8-pre1 (protocol 44)
motd: A Minecraft Server
players: 0/20
  foo (497dcba3-ecbf-4587-a2dd-5eb0665e6880)
  bar (50e14f43-dd4e-412f-864d-78943ea28d91)
  baz (7edb3b2e-869c-485b-af70-76a934e0fcfd)
ping: 0.00 ms
```