### PR TITLE
Migrate to main primary branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ on:
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       - "v*"
     branches:
-      # Also run on every commit to master. This allows us to test the build & release pipeline and eventually leads to a
+      # Also run on every commit to main. This allows us to test the build & release pipeline and eventually leads to a
       # Test PyPI release. Unlike with a tag push, this will not release a full PyPI release, nor create a GitHub release.
-      - master
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Once merged, we will want to rename the primary branch from `master` to `main`, this just updates the references in the CI to use the `main` branch.

AFAIK, there is nothing else that relies on the default branch being called master, but we might want to check to make sure.