### PR TITLE
Fix "Class-scoped fixture defined as instance method is deprecated"

### DIFF
--- a/tests/motd/test_transformers.py
+++ b/tests/motd/test_transformers.py
@@ -20,7 +20,8 @@ def test_nothing_transformer():
 
 class TestMotdPlain:
     @pytest.fixture(scope="class")
-    def result(self) -> MotdParseFunc:
+    @staticmethod
+    def result() -> MotdParseFunc:
         return lambda text: Motd.parse(text).to_plain()
 
     def test_plain_text(self, result: MotdParseFunc):
@@ -38,11 +39,13 @@ class TestMotdPlain:
 
 class TestMotdMinecraft:
     @pytest.fixture(scope="class")
-    def result(self) -> MotdParseFunc:
+    @staticmethod
+    def result() -> MotdParseFunc:
         return lambda text: Motd.parse(text).to_minecraft()
 
     @pytest.mark.parametrize("motd", ["&1&2&3", "§123§5bc", "§1§2§3"])
-    def test_return_the_same(self, motd: str, result: MotdParseFunc):
+    @staticmethod
+    def test_return_the_same(motd: str, result: MotdParseFunc):
         assert result(motd) == motd.replace("&", "§")
 
     def test_skip_web_colors(self, result: MotdParseFunc):
@@ -51,7 +54,8 @@ class TestMotdMinecraft:
 
 class TestMotdHTML:
     @pytest.fixture(scope="class")
-    def result(self) -> MotdParseFuncBedrockFlag:
+    @staticmethod
+    def result() -> MotdParseFuncBedrockFlag:
         return lambda text, bedrock: Motd.parse(text, bedrock=bedrock).to_html()
 
     def test_correct_output_java(self, result: MotdParseFuncBedrockFlag, source_java: RawJavaResponseMotd):
@@ -122,7 +126,8 @@ class TestMotdHTML:
 
 class TestMotdAnsi:
     @pytest.fixture(scope="class")
-    def result(self) -> MotdParseFuncBedrockFlag:
+    @staticmethod
+    def result() -> MotdParseFuncBedrockFlag:
         return lambda text, bedrock: Motd.parse(text, bedrock=bedrock).to_ansi()
 
     def test_correct_output_java(self, result: MotdParseFuncBedrockFlag, source_java: RawJavaResponseMotd):

--- a/tests/protocol/test_connection.py
+++ b/tests/protocol/test_connection.py
@@ -266,7 +266,8 @@ class TestBuffer:
 
 class TestTCPSocketConnection:
     @pytest.fixture(scope="class")
-    def connection(self) -> Iterator[TCPSocketConnection]:
+    @staticmethod
+    def connection() -> Iterator[TCPSocketConnection]:
         test_addr = Address("localhost", 1234)
 
         socket = Mock()
@@ -302,7 +303,8 @@ class TestTCPSocketConnection:
 
 class TestUDPSocketConnection:
     @pytest.fixture(scope="class")
-    def connection(self) -> Iterator[UDPSocketConnection]:
+    @staticmethod
+    def connection() -> Iterator[UDPSocketConnection]:
         test_addr = Address("127.0.0.1", 1234)
 
         socket = Mock()

--- a/tests/responses/test_bedrock.py
+++ b/tests/responses/test_bedrock.py
@@ -51,7 +51,8 @@ class TestBedrockStatusResponse(BaseResponseTest):
     ]
 
     @pytest.fixture(scope="class")
-    def build(self, build: BedrockStatusResponse) -> BedrockStatusResponse:
+    @staticmethod
+    def build(build: BedrockStatusResponse) -> BedrockStatusResponse:
         return build
 
     @pytest.mark.parametrize(("field", "pop_index"), [("map_name", 7), ("gamemode", 7), ("gamemode", 8)])
@@ -95,7 +96,8 @@ class TestBedrockStatusPlayers(BaseResponseTest):
     EXPECTED_VALUES: t.ClassVar = [("online", 1), ("max", 69)]
 
     @pytest.fixture(scope="class")
-    def build(self, build: BaseStatusResponse) -> BaseStatusPlayers:
+    @staticmethod
+    def build(build: BaseStatusResponse) -> BaseStatusPlayers:
         return build.players
 
 
@@ -105,5 +107,6 @@ class TestBedrockStatusVersion(BaseResponseTest):
     EXPECTED_VALUES: t.ClassVar = [("name", "1.18.100500"), ("protocol", 422), ("brand", "MCPE")]
 
     @pytest.fixture(scope="class")
-    def build(self, build: BaseStatusResponse) -> BaseStatusVersion:
+    @staticmethod
+    def build(build: BaseStatusResponse) -> BaseStatusVersion:
         return build.version

--- a/tests/responses/test_forge_data.py
+++ b/tests/responses/test_forge_data.py
@@ -48,8 +48,9 @@ class TestForgeDataV1(BaseResponseTest):
     ]
 
     @pytest.fixture(scope="class")
-    def build(self) -> ForgeData:
-        return ForgeData.build(self.RAW)  # pyright: ignore[reportArgumentType] # dict[str, Unknown] cannot be assigned to TypedDict
+    @classmethod
+    def build(cls) -> ForgeData:
+        return ForgeData.build(cls.RAW)  # pyright: ignore[reportArgumentType] # dict[str, Unknown] cannot be assigned to TypedDict
 
 
 @t.final
@@ -74,8 +75,9 @@ class TestForgeDataV2(BaseResponseTest):
     ]
 
     @pytest.fixture(scope="class")
-    def build(self) -> ForgeData:
-        return ForgeData.build(self.RAW)  # pyright: ignore[reportArgumentType] # dict[str, Unknown] cannot be assigned to TypedDict
+    @classmethod
+    def build(cls) -> ForgeData:
+        return ForgeData.build(cls.RAW)  # pyright: ignore[reportArgumentType] # dict[str, Unknown] cannot be assigned to TypedDict
 
 
 @t.final
@@ -116,8 +118,9 @@ class TestForgeDataV3(BaseResponseTest):
     ]
 
     @pytest.fixture(scope="class")
-    def build(self) -> ForgeData:
-        return ForgeData.build(self.RAW)  # pyright: ignore[reportArgumentType] # dict[str, Unknown] cannot be assigned to TypedDict
+    @classmethod
+    def build(cls) -> ForgeData:
+        return ForgeData.build(cls.RAW)  # pyright: ignore[reportArgumentType] # dict[str, Unknown] cannot be assigned to TypedDict
 
 
 @t.final
@@ -550,7 +553,8 @@ class TestForgeData(BaseResponseTest):
     ]
 
     @pytest.fixture(scope="class")
-    def build(self) -> ForgeData:
+    @staticmethod
+    def build() -> ForgeData:
         value = ForgeData.build(
             RawForgeData(
                 {

--- a/tests/responses/test_java.py
+++ b/tests/responses/test_java.py
@@ -40,8 +40,9 @@ class TestJavaStatusResponse(BaseResponseTest):
     )
 
     @pytest.fixture(scope="class")
-    def build(self) -> JavaStatusResponse:
-        return JavaStatusResponse.build(self.RAW)  # pyright: ignore[reportArgumentType] # dict[str, Unknown] cannot be assigned to TypedDict
+    @classmethod
+    def build(cls) -> JavaStatusResponse:
+        return JavaStatusResponse.build(cls.RAW)  # pyright: ignore[reportArgumentType] # dict[str, Unknown] cannot be assigned to TypedDict
 
     def test_as_dict(self, build: JavaStatusResponse):
         assert build.as_dict() == {
@@ -94,7 +95,8 @@ class TestJavaStatusPlayers(BaseResponseTest):
     )
 
     @pytest.fixture(scope="class")
-    def build(self) -> JavaStatusPlayers:
+    @staticmethod
+    def build() -> JavaStatusPlayers:
         return JavaStatusPlayers.build(
             {
                 "max": 20,
@@ -130,7 +132,8 @@ class TestJavaStatusPlayer(BaseResponseTest):
     EXPECTED_VALUES: t.ClassVar = [("name", "foo"), ("id", "0b3717c4-f45d-47c8-b8e2-3d9ff6f93a89")]
 
     @pytest.fixture(scope="class")
-    def build(self) -> JavaStatusPlayer:
+    @staticmethod
+    def build() -> JavaStatusPlayer:
         return JavaStatusPlayer.build({"name": "foo", "id": "0b3717c4-f45d-47c8-b8e2-3d9ff6f93a89"})
 
     def test_id_field_the_same_as_uuid(self) -> None:
@@ -146,5 +149,6 @@ class TestJavaStatusVersion(BaseResponseTest):
     EXPECTED_VALUES: t.ClassVar = [("name", "1.8-pre1"), ("protocol", 44)]
 
     @pytest.fixture(scope="class")
-    def build(self) -> JavaStatusVersion:
+    @staticmethod
+    def build() -> JavaStatusVersion:
         return JavaStatusVersion.build({"name": "1.8-pre1", "protocol": 44})

--- a/tests/responses/test_legacy.py
+++ b/tests/responses/test_legacy.py
@@ -34,7 +34,8 @@ class TestLegacyStatusResponse(BaseResponseTest):
     ]
 
     @pytest.fixture(scope="class")
-    def build(self, build: LegacyStatusResponse) -> LegacyStatusResponse:
+    @staticmethod
+    def build(build: LegacyStatusResponse) -> LegacyStatusResponse:
         return build
 
     def test_as_dict(self, build: LegacyStatusResponse):
@@ -52,7 +53,8 @@ class TestLegacyStatusPlayers(BaseResponseTest):
     EXPECTED_VALUES: t.ClassVar = [("online", 0), ("max", 20)]
 
     @pytest.fixture(scope="class")
-    def build(self, build: LegacyStatusResponse) -> LegacyStatusPlayers:
+    @staticmethod
+    def build(build: LegacyStatusResponse) -> LegacyStatusPlayers:
         return build.players
 
 
@@ -62,5 +64,6 @@ class TestLegacyStatusVersion(BaseResponseTest):
     EXPECTED_VALUES: t.ClassVar = [("name", "1.4.2"), ("protocol", 47)]
 
     @pytest.fixture(scope="class")
-    def build(self, build: LegacyStatusResponse) -> LegacyStatusVersion:
+    @staticmethod
+    def build(build: LegacyStatusResponse) -> LegacyStatusVersion:
         return build.version

--- a/tests/responses/test_query.py
+++ b/tests/responses/test_query.py
@@ -38,8 +38,9 @@ class TestQueryResponse(BaseResponseTest):
     ]
 
     @pytest.fixture(scope="class")
-    def build(self):
-        return QueryResponse.build(raw=self.RAW, players_list=self.RAW_PLAYERS)
+    @classmethod
+    def build(cls):
+        return QueryResponse.build(raw=cls.RAW, players_list=cls.RAW_PLAYERS)
 
     def test_as_dict(self, build: QueryResponse):
         assert build.as_dict() == {
@@ -88,7 +89,8 @@ class TestQueryPlayers(BaseResponseTest):
     ]
 
     @pytest.fixture(scope="class")
-    def build(self):
+    @staticmethod
+    def build():
         return QueryPlayers.build(
             raw={
                 "hostname": "A Minecraft Server",


### PR DESCRIPTION
```
=============================== warnings summary ===============================
tests/motd/test_transformers.py: 4 warnings
tests/protocol/test_connection.py: 2 warnings
tests/responses/test_bedrock.py: 3 warnings
tests/responses/test_forge_data.py: 4 warnings
tests/responses/test_java.py: 4 warnings
tests/responses/test_legacy.py: 3 warnings
tests/responses/test_query.py: 2 warnings
  /home/perchun/dev/mcstatus/.venv/lib/python3.14/site-packages/_pytest/fixtures.py:1313: PytestRemovedIn10Warning: Class-scoped fixture defined as instance method is deprecated.
  Instance attributes set in this fixture will NOT be visible to test methods,
  as each test gets a new instance while the fixture runs only once per class.
  Use @classmethod decorator and set attributes on cls instead.
  See https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method
    fixturefunc = resolve_fixture_function(fixturedef, request)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```