### PR TITLE
Ignore tests coverage on `t.TYPE_CHECKING` lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ skip_empty = false
 sort = "cover"
 exclude_lines = [
   "\\#\\s*pragma: no cover",
-  "^\\s*if (t|typing\\.)?TYPE_CHECKING:",
+  "^\\s*if (t\\.|typing\\.)?TYPE_CHECKING:",
   "^\\s*@(t|typing\\.)?overload",
   "^\\s*@(abc\\.)?abstractmethod",
   "^\\s*def __repr__\\(",


### PR DESCRIPTION
Before, the regex only matched `tTYPE_CHECKING` (without dot)