### PR TITLE
motd: separate parsing colors logic for java and bedrock

### DIFF
--- a/mcstatus/motd/_motd.py
+++ b/mcstatus/motd/_motd.py
@@ -6,7 +6,15 @@ from dataclasses import dataclass
 
 from mcstatus.motd._simplifies import get_unused_elements, squash_nearby_strings
 from mcstatus.motd._transformers import AnsiTransformer, HtmlTransformer, MinecraftTransformer, PlainTransformer
-from mcstatus.motd.components import Formatting, MinecraftColor, ParsedMotdComponent, TranslationTag, WebColor
+from mcstatus.motd.components import (
+    BedrockFormatting,
+    BedrockMinecraftColor,
+    JavaFormatting,
+    JavaMinecraftColor,
+    ParsedMotdComponent,
+    TranslationTag,
+    WebColor,
+)
 
 if t.TYPE_CHECKING:
     from typing_extensions import Self
@@ -79,10 +87,14 @@ class Motd:
 
         :param raw: Raw MOTD, directly from server.
         :param bedrock: Is server Bedrock Edition?
-            Ignores :attr:`MinecraftColor.MINECOIN_GOLD` if it's :obj:`False`.
+            If it isn't, ignores any color that starts with ``MATERIAL`` or
+            :attr:`MinecraftColor.MINECOIN_GOLD`.
         :returns: :obj:`ParsedMotdComponent` list, which need to be passed to ``__init__``.
         """
         parsed_motd: list[ParsedMotdComponent] = []
+
+        color_enum = BedrockMinecraftColor if bedrock else JavaMinecraftColor
+        formatting_enum = BedrockFormatting if bedrock else JavaFormatting
 
         split_raw = _MOTD_COLORS_RE.split(raw)
         for element in split_raw:
@@ -92,16 +104,12 @@ class Motd:
             clean_element = element.lstrip("&§").lower()
             standardized_element = element.replace("&", "§").lower()
 
-            if standardized_element == "§g" and not bedrock:
-                parsed_motd.append(element)  # minecoin_gold on java server, treat as string
-                continue
-
             if standardized_element.startswith("§"):
                 try:
-                    parsed_motd.append(MinecraftColor(clean_element))
+                    parsed_motd.append(color_enum(clean_element))
                 except ValueError:
                     try:
-                        parsed_motd.append(Formatting(clean_element))
+                        parsed_motd.append(formatting_enum(clean_element))
                     except ValueError:
                         # just a text
                         parsed_motd.append(element)
@@ -115,7 +123,7 @@ class Motd:
         cls,
         item: RawJavaResponseMotdWhenDict,
         *,
-        bedrock: bool = False,
+        bedrock: bool,
         auto_add: list[ParsedMotdComponent] | None = None,
     ) -> list[ParsedMotdComponent]:
         """Parse a MOTD when it's dict.
@@ -127,12 +135,13 @@ class Motd:
             Most time, this is :class:`Formatting` from top level.
         :returns: :obj:`ParsedMotdComponent` list, which need to be passed to ``__init__``.
         """
+        formatting_enum = BedrockFormatting if bedrock else JavaFormatting
         parsed_motd: list[ParsedMotdComponent] = auto_add if auto_add is not None else []
 
         if (color := item.get("color")) is not None:
-            parsed_motd.append(cls._parse_color(color))
+            parsed_motd.append(cls._parse_color(color, bedrock=bedrock))
 
-        for style_key, style_val in Formatting.__members__.items():
+        for style_key, style_val in formatting_enum.__members__.items():
             lowered_style_key = style_key.lower()
             if item.get(lowered_style_key) is False:
                 try:
@@ -147,14 +156,14 @@ class Motd:
             parsed_motd.extend(cls._parse_as_str(text, bedrock=bedrock))
         if (translate := item.get("translate")) is not None:
             parsed_motd.append(TranslationTag(translate))
-        parsed_motd.append(Formatting.RESET)
+        parsed_motd.append(formatting_enum.RESET)
 
         if "extra" in item:
-            auto_add = list(filter(lambda e: type(e) is Formatting and e != Formatting.RESET, parsed_motd))
+            auto_add = list(filter(lambda e: type(e) is formatting_enum and e != formatting_enum.RESET, parsed_motd))
 
             for element in item["extra"]:
                 parsed_motd.extend(
-                    cls._parse_as_dict(element, auto_add=auto_add.copy())
+                    cls._parse_as_dict(element, bedrock=bedrock, auto_add=auto_add.copy())
                     if isinstance(element, dict)
                     else auto_add + cls._parse_as_str(element, bedrock=bedrock)
                 )
@@ -162,10 +171,12 @@ class Motd:
         return parsed_motd
 
     @staticmethod
-    def _parse_color(color: str) -> ParsedMotdComponent:
+    def _parse_color(color: str, *, bedrock: bool) -> ParsedMotdComponent:
         """Parse a color string."""
+        color_enum = BedrockMinecraftColor if bedrock else JavaMinecraftColor
+        formatting_enum = BedrockFormatting if bedrock else JavaFormatting
         try:
-            return MinecraftColor[color.upper()]
+            return color_enum[color.upper()]
         except KeyError:
             if color == "reset":
                 # Minecraft servers actually can't return {"reset": True}, instead, they treat
@@ -175,7 +186,7 @@ class Motd:
                 #
                 # see `color` field in
                 # https://minecraft.wiki/w/Java_Edition_protocol/Chat?oldid=2763811#Shared_between_all_components
-                return Formatting.RESET
+                return formatting_enum.RESET
 
             # Last attempt: try parsing as HTML (hex rgb) color. Some servers use these to
             # achieve gradients.
@@ -210,7 +221,7 @@ class Motd:
         Example:
             ``&0Hello &oWorld`` turns into ``Hello World``.
         """
-        return PlainTransformer().transform(self.parsed)
+        return PlainTransformer(bedrock=self.bedrock).transform(self.parsed)
 
     def to_minecraft(self) -> str:
         """Transform MOTD to the Minecraft representation.
@@ -223,7 +234,7 @@ class Motd:
                 >>> Motd.parse("&0Hello &oWorld")
                 "§0Hello §oWorld"
         """
-        return MinecraftTransformer().transform(self.parsed)
+        return MinecraftTransformer(bedrock=self.bedrock).transform(self.parsed)
 
     def to_html(self) -> str:
         """Transform MOTD to the HTML format.

--- a/mcstatus/motd/_simplifies.py
+++ b/mcstatus/motd/_simplifies.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import typing as t
 
-from mcstatus.motd.components import Formatting, MinecraftColor, ParsedMotdComponent, WebColor
+from mcstatus.motd.components import (
+    AnyFormatting,
+    AnyMinecraftColor,
+    BedrockMinecraftColor,
+    JavaMinecraftColor,
+    ParsedMotdComponent,
+    WebColor,
+)
 
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -79,7 +86,7 @@ def get_double_items(parsed: Sequence[ParsedMotdComponent]) -> set[int]:
         except IndexError:  # Last item (without any next item)
             break
 
-        if isinstance(item, (Formatting, MinecraftColor, WebColor)) and item == next_item:
+        if isinstance(item, (AnyFormatting, AnyMinecraftColor, WebColor)) and item == next_item:
             to_remove.add(index)
 
     return to_remove
@@ -96,7 +103,7 @@ def get_double_colors(parsed: Sequence[ParsedMotdComponent]) -> set[int]:
 
     prev_color: int | None = None
     for index, item in enumerate(parsed):
-        if isinstance(item, (MinecraftColor, WebColor)):
+        if isinstance(item, (AnyMinecraftColor, WebColor)):
             # If we found a color after another, remove the previous color
             if prev_color is not None:
                 to_remove.add(prev_color)
@@ -122,7 +129,7 @@ def get_formatting_before_color(parsed: Sequence[ParsedMotdComponent]) -> set[in
     collected_formattings: list[int] = []
     for index, item in enumerate(parsed):
         # Collect the indices of formatting items
-        if isinstance(item, Formatting):
+        if isinstance(item, AnyFormatting):
             collected_formattings.append(index)
 
         # Only run checks if we have some collected formatting items
@@ -138,7 +145,7 @@ def get_formatting_before_color(parsed: Sequence[ParsedMotdComponent]) -> set[in
         # If there's a color after some formattings, these formattings will be overridden
         # as colors reset everything. This makes these formattings pointless, mark them
         # for removal.
-        if isinstance(item, (MinecraftColor, WebColor)):
+        if isinstance(item, (AnyMinecraftColor, WebColor)):
             to_remove.update(collected_formattings)
             collected_formattings = []
     return to_remove
@@ -159,7 +166,7 @@ def get_end_non_text(parsed: Sequence[ParsedMotdComponent]) -> set[int]:
             break
 
         # Remove any color/formatting that doesn't apply to text
-        if isinstance(item, (MinecraftColor, WebColor, Formatting)):
+        if isinstance(item, (AnyMinecraftColor, AnyFormatting, WebColor)):
             index = len(parsed) - 1 - rev_index
             to_remove.add(index)
 
@@ -169,16 +176,16 @@ def get_end_non_text(parsed: Sequence[ParsedMotdComponent]) -> set[int]:
 def get_meaningless_resets_and_colors(parsed: Sequence[ParsedMotdComponent]) -> set[int]:
     to_remove: set[int] = set()
 
-    active_color: MinecraftColor | WebColor | None = None
-    active_formatting: Formatting | None = None
+    active_color: AnyMinecraftColor | WebColor | None = None
+    active_formatting: AnyFormatting | None = None
     for index, item in enumerate(parsed):
-        if isinstance(item, (MinecraftColor, WebColor)):
+        if isinstance(item, (JavaMinecraftColor, BedrockMinecraftColor, WebColor)):
             if active_color == item:
                 to_remove.add(index)
             active_color = item
             continue
-        if isinstance(item, Formatting):
-            if item == Formatting.RESET:
+        if isinstance(item, AnyFormatting):
+            if item.name == "RESET":
                 if active_color is None and active_formatting is None:
                     to_remove.add(index)
                     continue

--- a/mcstatus/motd/_transformers.py
+++ b/mcstatus/motd/_transformers.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import abc
 import typing as t
 
-from mcstatus.motd.components import Formatting, MinecraftColor, ParsedMotdComponent, TranslationTag, WebColor
+from mcstatus.motd.components import (
+    AnyFormatting,
+    AnyMinecraftColor,
+    BedrockFormatting,
+    BedrockMinecraftColor,
+    JavaFormatting,
+    JavaMinecraftColor,
+    ParsedMotdComponent,
+    TranslationTag,
+    WebColor,
+)
 
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -24,43 +34,43 @@ _END_RESULT_TYPE = t.TypeVar("_END_RESULT_TYPE")
 
 # MinecraftColor: (foreground, background) # noqa: ERA001 # commented-out code
 _SHARED_MINECRAFT_COLOR_TO_RGB = {
-    MinecraftColor.BLACK: ((0, 0, 0), (0, 0, 0)),
-    MinecraftColor.DARK_BLUE: ((0, 0, 170), (0, 0, 42)),
-    MinecraftColor.DARK_GREEN: ((0, 170, 0), (0, 42, 0)),
-    MinecraftColor.DARK_AQUA: ((0, 170, 170), (0, 42, 42)),
-    MinecraftColor.DARK_RED: ((170, 0, 0), (42, 0, 0)),
-    MinecraftColor.DARK_PURPLE: ((170, 0, 170), (42, 0, 42)),
-    MinecraftColor.GOLD: ((255, 170, 0), (64, 42, 0)),
-    MinecraftColor.GRAY: ((170, 170, 170), (42, 42, 42)),
-    MinecraftColor.DARK_GRAY: ((85, 85, 85), (21, 21, 21)),
-    MinecraftColor.BLUE: ((85, 85, 255), (21, 21, 63)),
-    MinecraftColor.GREEN: ((85, 255, 85), (21, 63, 21)),
-    MinecraftColor.AQUA: ((85, 255, 255), (21, 63, 63)),
-    MinecraftColor.RED: ((255, 85, 85), (63, 21, 21)),
-    MinecraftColor.LIGHT_PURPLE: ((255, 85, 255), (63, 21, 63)),
-    MinecraftColor.YELLOW: ((255, 255, 85), (63, 63, 21)),
-    MinecraftColor.WHITE: ((255, 255, 255), (63, 63, 63)),
+    "BLACK": ((0, 0, 0), (0, 0, 0)),
+    "DARK_BLUE": ((0, 0, 170), (0, 0, 42)),
+    "DARK_GREEN": ((0, 170, 0), (0, 42, 0)),
+    "DARK_AQUA": ((0, 170, 170), (0, 42, 42)),
+    "DARK_RED": ((170, 0, 0), (42, 0, 0)),
+    "DARK_PURPLE": ((170, 0, 170), (42, 0, 42)),
+    "GOLD": ((255, 170, 0), (64, 42, 0)),
+    "GRAY": ((170, 170, 170), (42, 42, 42)),
+    "DARK_GRAY": ((85, 85, 85), (21, 21, 21)),
+    "BLUE": ((85, 85, 255), (21, 21, 63)),
+    "GREEN": ((85, 255, 85), (21, 63, 21)),
+    "AQUA": ((85, 255, 255), (21, 63, 63)),
+    "RED": ((255, 85, 85), (63, 21, 21)),
+    "LIGHT_PURPLE": ((255, 85, 255), (63, 21, 63)),
+    "YELLOW": ((255, 255, 85), (63, 63, 21)),
+    "WHITE": ((255, 255, 255), (63, 63, 63)),
 }
 
 _MINECRAFT_COLOR_TO_RGB_JAVA = _SHARED_MINECRAFT_COLOR_TO_RGB.copy()
-_MINECRAFT_COLOR_TO_RGB_JAVA[MinecraftColor.GRAY] = ((170, 170, 170), (42, 42, 42))
+_MINECRAFT_COLOR_TO_RGB_JAVA["GRAY"] = ((170, 170, 170), (42, 42, 42))
 
 _MINECRAFT_COLOR_TO_RGB_BEDROCK = _SHARED_MINECRAFT_COLOR_TO_RGB.copy()
 _MINECRAFT_COLOR_TO_RGB_BEDROCK.update(
     {
-        MinecraftColor.GRAY: ((198, 198, 198), (49, 49, 49)),
-        MinecraftColor.MINECOIN_GOLD: ((221, 214, 5), (55, 53, 1)),
-        MinecraftColor.MATERIAL_QUARTZ: ((227, 212, 209), (56, 53, 52)),
-        MinecraftColor.MATERIAL_IRON: ((206, 202, 202), (51, 50, 50)),
-        MinecraftColor.MATERIAL_NETHERITE: ((68, 58, 59), (17, 14, 14)),
-        MinecraftColor.MATERIAL_REDSTONE: ((151, 22, 7), (37, 5, 1)),
-        MinecraftColor.MATERIAL_COPPER: ((180, 104, 77), (45, 26, 19)),
-        MinecraftColor.MATERIAL_GOLD: ((222, 177, 45), (55, 44, 11)),
-        MinecraftColor.MATERIAL_EMERALD: ((17, 159, 54), (4, 40, 13)),
-        MinecraftColor.MATERIAL_DIAMOND: ((44, 186, 168), (11, 46, 42)),
-        MinecraftColor.MATERIAL_LAPIS: ((33, 73, 123), (8, 18, 30)),
-        MinecraftColor.MATERIAL_AMETHYST: ((154, 92, 198), (38, 23, 49)),
-        MinecraftColor.MATERIAL_RESIN: ((235, 114, 20), (59, 29, 5)),
+        "GRAY": ((198, 198, 198), (49, 49, 49)),
+        "MINECOIN_GOLD": ((221, 214, 5), (55, 53, 1)),
+        "MATERIAL_QUARTZ": ((227, 212, 209), (56, 53, 52)),
+        "MATERIAL_IRON": ((206, 202, 202), (51, 50, 50)),
+        "MATERIAL_NETHERITE": ((68, 58, 59), (17, 14, 14)),
+        "MATERIAL_REDSTONE": ((151, 22, 7), (37, 5, 1)),
+        "MATERIAL_COPPER": ((180, 104, 77), (45, 26, 19)),
+        "MATERIAL_GOLD": ((222, 177, 45), (55, 44, 11)),
+        "MATERIAL_EMERALD": ((17, 159, 54), (4, 40, 13)),
+        "MATERIAL_DIAMOND": ((44, 186, 168), (11, 46, 42)),
+        "MATERIAL_LAPIS": ((33, 73, 123), (8, 18, 30)),
+        "MATERIAL_AMETHYST": ((154, 92, 198), (38, 23, 49)),
+        "MATERIAL_RESIN": ((235, 114, 20), (59, 29, 5)),
     }
 )
 
@@ -75,6 +85,10 @@ class _BaseTransformer(abc.ABC, t.Generic[_HOOK_RETURN_TYPE, _END_RESULT_TYPE]):
     :type:`~mcstatus.motd.components.ParsedMotdComponent` individually.
     """
 
+    # TODO: When dropping v13 support, make sure to drop the default value for the bedrock arg
+    def __init__(self, *, bedrock: bool = False) -> None:
+        self.bedrock: bool = bedrock
+
     def transform(self, motd_components: Sequence[ParsedMotdComponent]) -> _END_RESULT_TYPE:
         return self._format_output([handled for component in motd_components for handled in self._handle_component(component)])
 
@@ -84,13 +98,15 @@ class _BaseTransformer(abc.ABC, t.Generic[_HOOK_RETURN_TYPE, _END_RESULT_TYPE]):
     def _handle_component(
         self, component: ParsedMotdComponent
     ) -> tuple[_HOOK_RETURN_TYPE, _HOOK_RETURN_TYPE] | tuple[_HOOK_RETURN_TYPE]:
+        color_enum = BedrockMinecraftColor if self.bedrock else JavaMinecraftColor
+        formatting_enum = BedrockFormatting if self.bedrock else JavaFormatting
 
         def handler(component: ParsedMotdComponent) -> _HOOK_RETURN_TYPE:
-            if type(component) is MinecraftColor:
+            if type(component) is color_enum:
                 return self._handle_minecraft_color(component)
             if type(component) is WebColor:
                 return self._handle_web_color(component)
-            if type(component) is Formatting:
+            if type(component) is formatting_enum:
                 return self._handle_formatting(component)
             if type(component) is TranslationTag:
                 return self._handle_translation_tag(component)
@@ -100,8 +116,8 @@ class _BaseTransformer(abc.ABC, t.Generic[_HOOK_RETURN_TYPE, _END_RESULT_TYPE]):
             raise RuntimeError(f"Invalid component type: {type(component)}: {component!r}")
 
         additional = None
-        if isinstance(component, MinecraftColor):
-            additional = self._handle_formatting(Formatting.RESET)
+        if isinstance(component, color_enum):
+            additional = self._handle_formatting(formatting_enum.RESET)
 
         return (additional, handler(component)) if additional is not None else (handler(component),)
 
@@ -115,10 +131,10 @@ class _BaseTransformer(abc.ABC, t.Generic[_HOOK_RETURN_TYPE, _END_RESULT_TYPE]):
     def _handle_web_color(self, element: WebColor, /) -> _HOOK_RETURN_TYPE: ...
 
     @abc.abstractmethod
-    def _handle_formatting(self, element: Formatting, /) -> _HOOK_RETURN_TYPE: ...
+    def _handle_formatting(self, element: AnyFormatting, /) -> _HOOK_RETURN_TYPE: ...
 
     @abc.abstractmethod
-    def _handle_minecraft_color(self, element: MinecraftColor, /) -> _HOOK_RETURN_TYPE: ...
+    def _handle_minecraft_color(self, element: AnyMinecraftColor, /) -> _HOOK_RETURN_TYPE: ...
 
 
 class _NothingTransformer(_BaseTransformer[str, str]):
@@ -136,7 +152,7 @@ class _NothingTransformer(_BaseTransformer[str, str]):
         return ""
 
     @override
-    def _handle_minecraft_color(self, _element: MinecraftColor, /) -> str:
+    def _handle_minecraft_color(self, _element: AnyMinecraftColor, /) -> str:
         return ""
 
     @override
@@ -144,7 +160,7 @@ class _NothingTransformer(_BaseTransformer[str, str]):
         return ""
 
     @override
-    def _handle_formatting(self, _element: Formatting, /) -> str:
+    def _handle_formatting(self, _element: AnyFormatting, /) -> str:
         return ""
 
     @override
@@ -168,26 +184,26 @@ class MinecraftTransformer(PlainTransformer):
         return result
 
     @override
-    def _handle_minecraft_color(self, element: MinecraftColor, /) -> str:
+    def _handle_minecraft_color(self, element: AnyMinecraftColor, /) -> str:
         return "§" + element.value
 
     @override
-    def _handle_formatting(self, element: Formatting, /) -> str:
+    def _handle_formatting(self, element: AnyFormatting, /) -> str:
         return "§" + element.value
 
 
 @t.final
 class HtmlTransformer(PlainTransformer):
     _FORMATTING_TO_HTML_TAGS: t.ClassVar = {
-        Formatting.BOLD: "b",
-        Formatting.STRIKETHROUGH: "s",
-        Formatting.ITALIC: "i",
-        Formatting.UNDERLINED: "u",
+        "BOLD": "b",
+        "STRIKETHROUGH": "s",
+        "ITALIC": "i",
+        "UNDERLINED": "u",
     }
 
     # TODO: When dropping v13 support, make sure to drop the default value for the bedrock arg
     def __init__(self, *, bedrock: bool = False) -> None:
-        self.bedrock = bedrock
+        super().__init__(bedrock=bedrock)
         self.on_reset: list[str] = []
 
     @override
@@ -204,9 +220,9 @@ class HtmlTransformer(PlainTransformer):
         return element.replace("\n", "<br>")
 
     @override
-    def _handle_minecraft_color(self, element: MinecraftColor, /) -> str:
+    def _handle_minecraft_color(self, element: AnyMinecraftColor, /) -> str:
         color_map = _MINECRAFT_COLOR_TO_RGB_BEDROCK if self.bedrock else _MINECRAFT_COLOR_TO_RGB_JAVA
-        fg_color, bg_color = color_map[element]
+        fg_color, bg_color = color_map[element.name]
 
         self.on_reset.append("</span>")
         return f"<span style='color:rgb{fg_color};text-shadow:0 0 1px rgb{bg_color}'>"
@@ -217,17 +233,17 @@ class HtmlTransformer(PlainTransformer):
         return f"<span style='color:rgb{element.rgb}'>"
 
     @override
-    def _handle_formatting(self, element: Formatting, /) -> str:
-        if element is Formatting.RESET:
+    def _handle_formatting(self, element: AnyFormatting, /) -> str:
+        if element.name == "RESET":
             to_return = "".join(self.on_reset)
             self.on_reset = []
             return to_return
 
-        if element is Formatting.OBFUSCATED:
+        if element.name == "OBFUSCATED":
             self.on_reset.append("</span>")
             return "<span class=obfuscated>"
 
-        tag_name = self._FORMATTING_TO_HTML_TAGS[element]
+        tag_name = self._FORMATTING_TO_HTML_TAGS[element.name]
         self.on_reset.append(f"</{tag_name}>")
         return f"<{tag_name}>"
 
@@ -235,11 +251,11 @@ class HtmlTransformer(PlainTransformer):
 @t.final
 class AnsiTransformer(PlainTransformer):
     _FORMATTING_TO_ANSI_TAGS: t.ClassVar = {
-        Formatting.BOLD: "1",
-        Formatting.STRIKETHROUGH: "9",
-        Formatting.ITALIC: "3",
-        Formatting.UNDERLINED: "4",
-        Formatting.OBFUSCATED: "5",
+        "BOLD": "1",
+        "STRIKETHROUGH": "9",
+        "ITALIC": "3",
+        "UNDERLINED": "4",
+        "OBFUSCATED": "5",
     }
     _MINECRAFT_COLOR_TO_RGB_JAVA: t.ClassVar = {
         key: foreground for key, (foreground, _background) in _MINECRAFT_COLOR_TO_RGB_JAVA.items()
@@ -250,13 +266,13 @@ class AnsiTransformer(PlainTransformer):
 
     # TODO: When dropping v13 support, make sure to drop the default value for the bedrock arg
     def __init__(self, *, bedrock: bool = True) -> None:
-        self.bedrock = bedrock
+        super().__init__(bedrock=bedrock)
 
-    def ansi_color(self, color: tuple[int, int, int] | MinecraftColor) -> str:
+    def ansi_color(self, color: tuple[int, int, int] | AnyMinecraftColor) -> str:
         """Transform RGB color to ANSI color code."""
-        if isinstance(color, MinecraftColor):
+        if isinstance(color, AnyMinecraftColor):
             color_to_rgb = self._MINECRAFT_COLOR_TO_RGB_BEDROCK if self.bedrock else self._MINECRAFT_COLOR_TO_RGB_JAVA
-            color = color_to_rgb[color]
+            color = color_to_rgb[color.name]
 
         return "\033[38;2;{};{};{}m".format(*color)
 
@@ -265,7 +281,7 @@ class AnsiTransformer(PlainTransformer):
         return "\033[0m" + super()._format_output(results) + "\033[0m"
 
     @override
-    def _handle_minecraft_color(self, element: MinecraftColor, /) -> str:
+    def _handle_minecraft_color(self, element: AnyMinecraftColor, /) -> str:
         return self.ansi_color(element)
 
     @override
@@ -273,7 +289,7 @@ class AnsiTransformer(PlainTransformer):
         return self.ansi_color(element.rgb)
 
     @override
-    def _handle_formatting(self, element: Formatting, /) -> str:
-        if element is Formatting.RESET:
+    def _handle_formatting(self, element: AnyFormatting, /) -> str:
+        if element.name == "RESET":
             return "\033[0m"
-        return "\033[" + self._FORMATTING_TO_ANSI_TAGS[element] + "m"
+        return "\033[" + self._FORMATTING_TO_ANSI_TAGS[element.name] + "m"

--- a/mcstatus/motd/components.py
+++ b/mcstatus/motd/components.py
@@ -8,8 +8,12 @@ if t.TYPE_CHECKING:
     from typing_extensions import Self
 
 __all__ = [
-    "Formatting",
-    "MinecraftColor",
+    "AnyFormatting",
+    "AnyMinecraftColor",
+    "BedrockFormatting",
+    "BedrockMinecraftColor",
+    "JavaFormatting",
+    "JavaMinecraftColor",
     "ParsedMotdComponent",
     "TranslationTag",
     "WebColor",
@@ -19,18 +23,14 @@ __all__ = [
 # NOTE: keep in sync with the definition in docs (`docs/api/motd_parsing.rst`)
 # the autodocs plugin does not support type aliases yet, so those have to be
 # defined manually in docs
-ParsedMotdComponent: t.TypeAlias = "Formatting | MinecraftColor | WebColor | TranslationTag | str"
+ParsedMotdComponent: t.TypeAlias = "AnyFormatting | AnyMinecraftColor | WebColor | TranslationTag | str"
 
 
-class Formatting(Enum):
-    """Enum for Formatting codes.
+class JavaFormatting(Enum):
+    """Enum for Java Formatting codes.
 
     See `Minecraft wiki <https://minecraft.wiki/w/Formatting_codes#Formatting_codes>`__
     for more info.
-
-    .. note::
-        :attr:`.STRIKETHROUGH` and :attr:`.UNDERLINED` don't work on Bedrock, which our parser
-        doesn't keep it in mind. See `MCPE-41729 <https://bugs.mojang.com/browse/MCPE-41729>`_.
     """
 
     BOLD = "l"
@@ -41,8 +41,25 @@ class Formatting(Enum):
     RESET = "r"
 
 
-class MinecraftColor(Enum):
-    """Enum for Color codes.
+class BedrockFormatting(Enum):
+    """Enum for Bedrock Formatting codes.
+
+    The same as :class:`.JavaFormatting`, but excludes
+    :attr:`JavaFormatting.UNDERLINED` and :attr:`JavaFormatting.STRIKETHROUGH`,
+    as they don't work on Bedrock (see `MCPE-41729 <https://bugs.mojang.com/browse/MCPE-41729>`_)
+
+    See `Minecraft wiki <https://minecraft.wiki/w/Formatting_codes#Formatting_codes>`__
+    for more info.
+    """
+
+    BOLD = "l"
+    ITALIC = "o"
+    OBFUSCATED = "k"
+    RESET = "r"
+
+
+class JavaMinecraftColor(Enum):
+    """Enum for Java color codes.
 
     See `Minecraft wiki <https://minecraft.wiki/w/Formatting_codes#Color_codes>`_
     for more info.
@@ -65,7 +82,31 @@ class MinecraftColor(Enum):
     YELLOW = "e"
     WHITE = "f"
 
-    # Only for bedrock
+
+class BedrockMinecraftColor(Enum):
+    """Enum for Bedrock color codes.
+
+    See `Minecraft wiki <https://minecraft.wiki/w/Formatting_codes#Color_codes>`_
+    for more info.
+    """
+
+    BLACK = "0"
+    DARK_BLUE = "1"
+    DARK_GREEN = "2"
+    DARK_AQUA = "3"
+    DARK_RED = "4"
+    DARK_PURPLE = "5"
+    GOLD = "6"
+    GRAY = "7"
+    DARK_GRAY = "8"
+    BLUE = "9"
+    GREEN = "a"
+    AQUA = "b"
+    RED = "c"
+    LIGHT_PURPLE = "d"
+    YELLOW = "e"
+    WHITE = "f"
+
     MINECOIN_GOLD = "g"
     MATERIAL_QUARTZ = "h"
     MATERIAL_IRON = "i"
@@ -78,6 +119,11 @@ class MinecraftColor(Enum):
     MATERIAL_LAPIS = "t"
     MATERIAL_AMETHYST = "u"
     MATERIAL_RESIN = "v"
+
+
+# having these as unions, means that we can use `isinstance`
+AnyFormatting: t.TypeAlias = JavaFormatting | BedrockFormatting
+AnyMinecraftColor: t.TypeAlias = JavaMinecraftColor | BedrockMinecraftColor
 
 
 @dataclass(frozen=True)

--- a/tests/motd/test_motd_parse.py
+++ b/tests/motd/test_motd_parse.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import pytest
 
 from mcstatus.motd import Motd
-from mcstatus.motd.components import Formatting, MinecraftColor, ParsedMotdComponent, TranslationTag
+from mcstatus.motd.components import (
+    BedrockFormatting,
+    BedrockMinecraftColor,
+    JavaFormatting,
+    JavaMinecraftColor,
+    ParsedMotdComponent,
+    TranslationTag,
+)
 from mcstatus.responses._raw import RawJavaResponseMotd, RawJavaResponseMotdWhenDict
 
 
@@ -12,62 +19,64 @@ class TestMotdParse:
         assert Motd.parse(source_bedrock, bedrock=True) == Motd(
             [
                 "1",
-                MinecraftColor.BLACK, Formatting.OBFUSCATED, "2",
-                MinecraftColor.DARK_BLUE, Formatting.BOLD, "3",
-                MinecraftColor.DARK_GREEN, Formatting.ITALIC, "4",
-                MinecraftColor.DARK_AQUA, "5",
-                MinecraftColor.DARK_RED, "6",
-                MinecraftColor.DARK_PURPLE, "7",
-                MinecraftColor.GOLD, "8",
-                MinecraftColor.GRAY, "9",
-                MinecraftColor.DARK_GRAY, "10",
-                MinecraftColor.BLUE, "11",
-                MinecraftColor.GREEN, "12",
-                MinecraftColor.AQUA, "13",
-                MinecraftColor.RED, "14",
-                MinecraftColor.LIGHT_PURPLE, "15",
-                MinecraftColor.YELLOW, "16",
-                MinecraftColor.WHITE, "17",
-                MinecraftColor.MINECOIN_GOLD, "18",
-                MinecraftColor.MATERIAL_QUARTZ, "19",
-                MinecraftColor.MATERIAL_IRON, "20",
-                MinecraftColor.MATERIAL_NETHERITE, "21",
-                MinecraftColor.MATERIAL_REDSTONE, "22",
-                MinecraftColor.MATERIAL_COPPER, "23",
-                MinecraftColor.MATERIAL_GOLD, "24",
-                MinecraftColor.MATERIAL_EMERALD, "25",
-                MinecraftColor.MATERIAL_DIAMOND, "26",
-                MinecraftColor.MATERIAL_LAPIS, "27",
-                MinecraftColor.MATERIAL_AMETHYST, "28",
-                MinecraftColor.MATERIAL_RESIN, "29",
-                Formatting.RESET, "30",
+                BedrockMinecraftColor.BLACK, BedrockFormatting.OBFUSCATED, "2",
+                BedrockMinecraftColor.DARK_BLUE, BedrockFormatting.BOLD, "3",
+                BedrockMinecraftColor.DARK_GREEN, BedrockFormatting.ITALIC, "4",
+                BedrockMinecraftColor.DARK_AQUA, "5",
+                BedrockMinecraftColor.DARK_RED, "6",
+                BedrockMinecraftColor.DARK_PURPLE, "7",
+                BedrockMinecraftColor.GOLD, "8",
+                BedrockMinecraftColor.GRAY, "9",
+                BedrockMinecraftColor.DARK_GRAY, "10",
+                BedrockMinecraftColor.BLUE, "11",
+                BedrockMinecraftColor.GREEN, "12",
+                BedrockMinecraftColor.AQUA, "13",
+                BedrockMinecraftColor.RED, "14",
+                BedrockMinecraftColor.LIGHT_PURPLE, "15",
+                BedrockMinecraftColor.YELLOW, "16",
+                BedrockMinecraftColor.WHITE, "17",
+                BedrockMinecraftColor.MINECOIN_GOLD, "18",
+                BedrockMinecraftColor.MATERIAL_QUARTZ, "19",
+                BedrockMinecraftColor.MATERIAL_IRON, "20",
+                BedrockMinecraftColor.MATERIAL_NETHERITE, "21",
+                BedrockMinecraftColor.MATERIAL_REDSTONE, "22",
+                BedrockMinecraftColor.MATERIAL_COPPER, "23",
+                BedrockMinecraftColor.MATERIAL_GOLD, "24",
+                BedrockMinecraftColor.MATERIAL_EMERALD, "25",
+                BedrockMinecraftColor.MATERIAL_DIAMOND, "26",
+                BedrockMinecraftColor.MATERIAL_LAPIS, "27",
+                BedrockMinecraftColor.MATERIAL_AMETHYST, "28",
+                BedrockMinecraftColor.MATERIAL_RESIN, "29",
+                BedrockFormatting.RESET, "30",
             ],
             bedrock=True,
             raw=source_bedrock,
         )  # fmt: skip
 
-    @pytest.mark.parametrize("bedrock", [True, False])
-    def test_bedrock_parameter_nothing_changes(self, bedrock: bool):
-        assert Motd.parse([{"color": "minecoin_gold", "text": " "}], bedrock=bedrock).parsed == [
-            Formatting.RESET,
-            MinecraftColor.MINECOIN_GOLD,
-            " ",
-            Formatting.RESET,
-        ]
-
-    @pytest.mark.parametrize(("bedrock", "expected"), [(True, MinecraftColor.MINECOIN_GOLD), (False, "&g")])
+    @pytest.mark.parametrize(("bedrock", "expected"), [(True, BedrockMinecraftColor.MINECOIN_GOLD), (False, "&g")])
     def test_parse_as_str_ignore_minecoin_gold_on_java(self, bedrock: bool, expected: ParsedMotdComponent):
         assert Motd.parse("&g", bedrock=bedrock).parsed == [expected]
+
+    @pytest.mark.parametrize(("bedrock", "expected"), [(True, BedrockMinecraftColor.MATERIAL_IRON), (False, "&i")])
+    def test_parse_as_str_ignore_material_colors_on_java(self, bedrock: bool, expected: ParsedMotdComponent):
+        assert Motd.parse("&i", bedrock=bedrock).parsed == [expected]
+
+    @pytest.mark.parametrize(
+        ("bedrock", "expected"), [(True, BedrockMinecraftColor.MATERIAL_COPPER), (False, JavaFormatting.UNDERLINED)]
+    )
+    def test_parse_as_str_underlined_on_java(self, bedrock: bool, expected: ParsedMotdComponent):
+        assert Motd.parse("&n", bedrock=bedrock).parsed == [expected]
 
     def test_parse_incorrect_color_passes(self):
         """See `https://github.com/py-mine/mcstatus/pull/335#discussion_r985084188`_."""
         assert Motd.parse("&z").parsed == ["&z"]
 
     def test_parse_uppercase_passes(self):
-        assert Motd.parse("&A").parsed == [MinecraftColor.GREEN]
+        assert Motd.parse("&A").parsed == [JavaMinecraftColor.GREEN]
 
     @pytest.mark.parametrize(
-        ("input_", "expected"), [("", []), ([], [Formatting.RESET]), ({"extra": [], "text": ""}, [Formatting.RESET])]
+        ("input_", "expected"),
+        [("", []), ([], [JavaFormatting.RESET]), ({"extra": [], "text": ""}, [JavaFormatting.RESET])],
     )
     def test_empty_input_also_empty_raw(self, input_: RawJavaResponseMotd, expected: list[ParsedMotdComponent]):
         assert Motd.parse(input_).parsed == expected
@@ -75,13 +84,13 @@ class TestMotdParse:
     def test_top_level_formatting_applies_to_all_in_extra(self) -> None:
         """As described `here <https://minecraft.wiki/w/Java_Edition_protocol/Chat?direction=prev&oldid=2763844#Inheritance>`_."""
         assert Motd.parse({"text": "top", "bold": True, "extra": [{"color": "red", "text": "not top"}]}).parsed == [
-            Formatting.BOLD,
+            JavaFormatting.BOLD,
             "top",
-            Formatting.RESET,
-            Formatting.BOLD,
-            MinecraftColor.RED,
+            JavaFormatting.RESET,
+            JavaFormatting.BOLD,
+            JavaMinecraftColor.RED,
             "not top",
-            Formatting.RESET,
+            JavaFormatting.RESET,
         ]
 
     def test_top_level_formatting_can_be_overwrote(self) -> None:
@@ -89,12 +98,12 @@ class TestMotdParse:
         assert Motd.parse(
             {"text": "bold", "bold": True, "extra": [{"color": "red", "bold": False, "text": "not bold"}]}
         ).parsed == [
-            Formatting.BOLD,
+            JavaFormatting.BOLD,
             "bold",
-            Formatting.RESET,
-            MinecraftColor.RED,
+            JavaFormatting.RESET,
+            JavaMinecraftColor.RED,
             "not bold",
-            Formatting.RESET,
+            JavaFormatting.RESET,
         ]
 
     def test_top_level_formatting_applies_to_string_inside_extra(self) -> None:
@@ -103,10 +112,10 @@ class TestMotdParse:
         See `#711 <https://github.com/py-mine/mcstatus/issues/711>`_.
         """
         assert Motd.parse({"text": "top", "bold": True, "extra": ["not top"]}).parsed == [
-            Formatting.BOLD,
+            JavaFormatting.BOLD,
             "top",
-            Formatting.RESET,
-            Formatting.BOLD,
+            JavaFormatting.RESET,
+            JavaFormatting.BOLD,
             "not top",
         ]
 
@@ -116,15 +125,15 @@ class TestMotdParse:
         See `https://github.com/py-mine/mcstatus/pull/335#discussion_r985086953`_.
         """
         assert Motd.parse({"color": "red", "bold": False, "text": "not bold"}).parsed == [
-            MinecraftColor.RED,
+            JavaMinecraftColor.RED,
             "not bold",
-            Formatting.RESET,
+            JavaFormatting.RESET,
         ]
 
     def test_translate_string(self):
         assert Motd.parse(RawJavaResponseMotdWhenDict(translate="the key")).parsed == [
             TranslationTag("the key"),
-            Formatting.RESET,
+            JavaFormatting.RESET,
         ]
 
     def test_short_text_is_not_considered_as_color(self):
@@ -133,7 +142,7 @@ class TestMotdParse:
 
     def test_text_field_contains_formatting(self):
         """See `https://github.com/py-mine/mcstatus/pull/335#issuecomment-1264191303`_."""
-        assert Motd.parse({"text": "&aHello!"}).parsed == [MinecraftColor.GREEN, "Hello!", Formatting.RESET]
+        assert Motd.parse({"text": "&aHello!"}).parsed == [JavaMinecraftColor.GREEN, "Hello!", JavaFormatting.RESET]
 
     def test_invalid_raw_input(self):
         obj = object()
@@ -143,9 +152,9 @@ class TestMotdParse:
         ):
             _ = Motd.parse(obj)  # pyright: ignore[reportArgumentType]
 
-    def test_invalid_color(self):
+    def test_parse_invalid_color(self):
         with pytest.raises(ValueError, match=r"^Unable to parse color: 'a', report this!$"):
-            _ = Motd._parse_color("a")
+            _ = Motd._parse_color("a", bedrock=False)
 
     def test_multiple_times_nested_extras(self):
         """See `https://discord.com/channels/936788458939224094/938591600160956446/1062860329597534258`_."""
@@ -177,27 +186,27 @@ class TestMotdParse:
             }
         )
         assert motd.parsed == [
-            Formatting.RESET, Formatting.RESET, Formatting.RESET,
+            JavaFormatting.RESET, JavaFormatting.RESET, JavaFormatting.RESET,
             "1",
-            Formatting.RESET, Formatting.RESET,
+            JavaFormatting.RESET, JavaFormatting.RESET,
             "2",
-            Formatting.RESET, Formatting.RESET,
+            JavaFormatting.RESET, JavaFormatting.RESET,
             "3",
-            Formatting.RESET, Formatting.RESET, Formatting.RESET,
+            JavaFormatting.RESET, JavaFormatting.RESET, JavaFormatting.RESET,
             "4",
-            Formatting.RESET, Formatting.RESET,
+            JavaFormatting.RESET, JavaFormatting.RESET,
             "5",
-            Formatting.RESET, Formatting.RESET,
+            JavaFormatting.RESET, JavaFormatting.RESET,
             "6",
-            Formatting.RESET, Formatting.RESET, Formatting.RESET,
+            JavaFormatting.RESET, JavaFormatting.RESET, JavaFormatting.RESET,
             "7",
-            Formatting.RESET, Formatting.RESET,
+            JavaFormatting.RESET, JavaFormatting.RESET,
             "8",
-            Formatting.RESET, Formatting.RESET,
+            JavaFormatting.RESET, JavaFormatting.RESET,
             "9",
-            Formatting.RESET,
+            JavaFormatting.RESET,
         ]  # fmt: skip
 
     def test_raw_attribute(self, source_bedrock: RawJavaResponseMotd):
-        motd = Motd.parse(source_bedrock)
+        motd = Motd.parse(source_bedrock, bedrock=True)
         assert motd.raw == source_bedrock

--- a/tests/motd/test_simplifies.py
+++ b/tests/motd/test_simplifies.py
@@ -15,7 +15,7 @@ from mcstatus.motd._simplifies import (
     get_meaningless_resets_and_colors,
     get_unused_elements,
 )
-from mcstatus.motd.components import Formatting, MinecraftColor, ParsedMotdComponent, TranslationTag, WebColor
+from mcstatus.motd.components import JavaFormatting, JavaMinecraftColor, ParsedMotdComponent, TranslationTag, WebColor
 
 
 class TestMotdSimplifies:
@@ -37,7 +37,7 @@ class TestMotdSimplifies:
                 simplifier.assert_called()
 
     def test_simplify_returns_new_instance(self):
-        parsed: list[ParsedMotdComponent] = [Formatting.RESET]
+        parsed: list[ParsedMotdComponent] = [JavaFormatting.RESET]
         obj = Motd(parsed.copy(), raw="")
         assert obj.simplify().parsed == []
         assert obj.parsed == parsed
@@ -47,17 +47,17 @@ class TestMotdSimplifies:
 
     def test_simplify_runs_few_times(self):
         """See `https://github.com/py-mine/mcstatus/pull/335#discussion_r1051658497`_."""
-        obj = Motd([Formatting.BOLD, Formatting.RESET, MinecraftColor.RED], raw="")
+        obj = Motd([JavaFormatting.BOLD, JavaFormatting.RESET, JavaMinecraftColor.RED], raw="")
         assert obj.simplify() == Motd([], raw="")
 
-    @pytest.mark.parametrize("first", [MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
-    @pytest.mark.parametrize("second", [MinecraftColor.BLUE, WebColor.from_hex(hex="#dd0220")])
+    @pytest.mark.parametrize("first", [JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("second", [JavaMinecraftColor.BLUE, WebColor.from_hex(hex="#dd0220")])
     def test_get_double_colors(self, first: ParsedMotdComponent, second: ParsedMotdComponent):
         assert get_double_colors([first, second]) == {0}
 
-    @pytest.mark.parametrize("first", [MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
-    @pytest.mark.parametrize("second", [MinecraftColor.BLUE, WebColor.from_hex(hex="#dd0220")])
-    @pytest.mark.parametrize("third", [MinecraftColor.BLUE, WebColor.from_hex(hex="dd0220")])
+    @pytest.mark.parametrize("first", [JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("second", [JavaMinecraftColor.BLUE, WebColor.from_hex(hex="#dd0220")])
+    @pytest.mark.parametrize("third", [JavaMinecraftColor.BLUE, WebColor.from_hex(hex="dd0220")])
     def test_get_double_colors_with_three_items(
         self,
         first: ParsedMotdComponent,
@@ -66,65 +66,69 @@ class TestMotdSimplifies:
     ):
         assert get_double_colors([first, second, third]) == {0, 1}
 
-    @pytest.mark.parametrize("first", [MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
-    @pytest.mark.parametrize("second", [MinecraftColor.BLUE, WebColor.from_hex(hex="#dd0220")])
+    @pytest.mark.parametrize("first", [JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("second", [JavaMinecraftColor.BLUE, WebColor.from_hex(hex="#dd0220")])
     def test_get_double_colors_with_no_double_colors(self, first: ParsedMotdComponent, second: ParsedMotdComponent):
         assert get_double_colors([first, "foo", second]) == set()
 
-    @pytest.mark.parametrize("item", [Formatting.BOLD, MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("item", [JavaFormatting.BOLD, JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
     def test_get_double_items(self, item: ParsedMotdComponent):
         assert get_double_items([item, item]) == {0}
 
-    @pytest.mark.parametrize("item", [Formatting.BOLD, MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("item", [JavaFormatting.BOLD, JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
     def test_get_double_items_with_three_items(self, item: ParsedMotdComponent):
         assert get_double_items([item, item, item]) == {0, 1}
 
-    @pytest.mark.parametrize("item", [Formatting.BOLD, MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("item", [JavaFormatting.BOLD, JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
     def test_get_double_items_with_no_double_items(self, item: ParsedMotdComponent):
         assert get_double_items([item, "foo", item]) == set()
 
-    @pytest.mark.parametrize("last_item", [MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("last_item", [JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
     def test_get_formatting_before_color(self, last_item: ParsedMotdComponent):
-        assert get_formatting_before_color([Formatting.BOLD, last_item]) == {0}
+        assert get_formatting_before_color([JavaFormatting.BOLD, last_item]) == {0}
 
-    @pytest.mark.parametrize("first_item", [Formatting.RESET, MinecraftColor.RED, WebColor.from_hex(hex="#ff0000"), "abc"])
+    @pytest.mark.parametrize(
+        "first_item", [JavaFormatting.RESET, JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000"), "abc"]
+    )
     def test_get_formatting_before_color_without_formatting_before_color(self, first_item: ParsedMotdComponent):
-        assert get_formatting_before_color([first_item, "abc", MinecraftColor.WHITE]) == set()
+        assert get_formatting_before_color([first_item, "abc", JavaMinecraftColor.WHITE]) == set()
 
     def test_skip_get_formatting_before_color(self):
-        assert get_formatting_before_color(["abc", Formatting.BOLD, "def", Formatting.RESET, "ghi"]) == set()
+        assert get_formatting_before_color(["abc", JavaFormatting.BOLD, "def", JavaFormatting.RESET, "ghi"]) == set()
 
-    @pytest.mark.parametrize("last_item", [MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("last_item", [JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
     def test_get_formatting_before_color_if_space_between(self, last_item: ParsedMotdComponent):
-        assert get_formatting_before_color([Formatting.BOLD, " ", last_item]) == {0}
+        assert get_formatting_before_color([JavaFormatting.BOLD, " ", last_item]) == {0}
 
     def test_two_formattings_before_minecraft_color(self):
         """See `https://github.com/py-mine/mcstatus/pull/335#discussion_r1048476090`_."""
-        assert get_formatting_before_color([Formatting.BOLD, Formatting.ITALIC, MinecraftColor.RED]) == {0, 1}
+        assert get_formatting_before_color([JavaFormatting.BOLD, JavaFormatting.ITALIC, JavaMinecraftColor.RED]) == {0, 1}
 
     def test_two_formattings_one_by_one(self):
-        obj = Motd([Formatting.BOLD, Formatting.ITALIC], raw="")
+        obj = Motd([JavaFormatting.BOLD, JavaFormatting.ITALIC], raw="")
         assert obj.simplify().parsed == []
 
-    @pytest.mark.parametrize("last_item", [Formatting.RESET, MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("last_item", [JavaFormatting.RESET, JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
     def test_non_text_in_the_end(self, last_item: ParsedMotdComponent):
-        assert get_end_non_text(["abc", Formatting.BOLD, "def", Formatting.RESET, "ghi", last_item]) == {5}
+        assert get_end_non_text(["abc", JavaFormatting.BOLD, "def", JavaFormatting.RESET, "ghi", last_item]) == {5}
 
     def test_translation_tag_in_the_end(self):
-        assert get_end_non_text(["abc", Formatting.BOLD, "def", Formatting.RESET, "ghi", TranslationTag("key")]) == set()
+        assert (
+            get_end_non_text(["abc", JavaFormatting.BOLD, "def", JavaFormatting.RESET, "ghi", TranslationTag("key")]) == set()
+        )
 
-    @pytest.mark.parametrize("item", [Formatting.BOLD, MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("item", [JavaFormatting.BOLD, JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
     def test_meaningless_resets_and_colors_active(self, item: ParsedMotdComponent):
         assert get_meaningless_resets_and_colors([item, "foo", item, "bar"]) == {2}
 
     def test_meaningless_resets_and_colors_reset_nothing(self):
-        assert get_meaningless_resets_and_colors(["foo", Formatting.RESET, "bar"]) == {1}
+        assert get_meaningless_resets_and_colors(["foo", JavaFormatting.RESET, "bar"]) == {1}
 
-    @pytest.mark.parametrize("item", [Formatting.BOLD, MinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
+    @pytest.mark.parametrize("item", [JavaFormatting.BOLD, JavaMinecraftColor.RED, WebColor.from_hex(hex="#ff0000")])
     def test_meaningless_resets_and_colors_resets(self, item: ParsedMotdComponent):
-        assert get_meaningless_resets_and_colors([item, "foo", Formatting.RESET, item, "bar"]) == set()
+        assert get_meaningless_resets_and_colors([item, "foo", JavaFormatting.RESET, item, "bar"]) == set()
 
-    def test_no_conflict_on_poping_items(self):
+    def test_no_conflict_on_popping_items(self):
         """See `https://github.com/py-mine/mcstatus/pull/335#discussion_r1045303652`_."""
         obj = Motd(["0", "1"], raw="")
         call_count = 0
@@ -155,11 +159,11 @@ class TestMotdSimplifies:
         assert Motd([" " * 20], raw="").simplify().parsed == [" " * 20]
 
     def test_simplify_meaningless_resets_and_colors(self):
-        assert Motd.parse("&a1&a2&a3").simplify().parsed == [MinecraftColor.GREEN, "123"]
+        assert Motd.parse("&a1&a2&a3").simplify().parsed == [JavaMinecraftColor.GREEN, "123"]
 
     def test_remove_formatting_reset_if_there_was_no_color_or_formatting(self):
         motd = Motd.parse({"text": "123", "extra": [{"text": "123"}]})
-        assert motd.parsed == ["123", Formatting.RESET, "123", Formatting.RESET]
+        assert motd.parsed == ["123", JavaFormatting.RESET, "123", JavaFormatting.RESET]
         assert motd.simplify().parsed == ["123123"]
 
     def test_squash_nearby_strings(self):

--- a/tests/motd/test_transformers.py
+++ b/tests/motd/test_transformers.py
@@ -15,7 +15,7 @@ MotdParseFuncBedrockFlag: typing.TypeAlias = Callable[[RawJavaResponseMotd, bool
 
 
 def test_nothing_transformer():
-    assert _NothingTransformer().transform(Motd.parse("&1a&bfoo&r").parsed) == ""
+    assert _NothingTransformer(bedrock=False).transform(Motd.parse("&1a&bfoo&r").parsed) == ""
 
 
 class TestMotdPlain:


### PR DESCRIPTION
Enums do not support inheritance, so I had to split Java and Bedrock colors/formattings into separate classes. This is ugly, and I don't like it, but I don't know a better way to do this.

Fixes https://github.com/py-mine/mcstatus/issues/1165