### PR TITLE
motd: ignore invalid formattings

### DIFF
--- a/mcstatus/motd/_motd.py
+++ b/mcstatus/motd/_motd.py
@@ -9,6 +9,7 @@ from mcstatus.motd._transformers import AnsiTransformer, HtmlTransformer, Minecr
 from mcstatus.motd.components import (
     BedrockFormatting,
     BedrockMinecraftColor,
+    InvalidFormatting,
     JavaFormatting,
     JavaMinecraftColor,
     ParsedMotdComponent,
@@ -111,8 +112,7 @@ class Motd:
                     try:
                         parsed_motd.append(formatting_enum(clean_element))
                     except ValueError:
-                        # just a text
-                        parsed_motd.append(element)
+                        parsed_motd.append(InvalidFormatting(clean_element))
             else:
                 parsed_motd.append(element)
 

--- a/mcstatus/motd/_transformers.py
+++ b/mcstatus/motd/_transformers.py
@@ -8,6 +8,7 @@ from mcstatus.motd.components import (
     AnyMinecraftColor,
     BedrockFormatting,
     BedrockMinecraftColor,
+    InvalidFormatting,
     JavaFormatting,
     JavaMinecraftColor,
     ParsedMotdComponent,
@@ -108,6 +109,8 @@ class _BaseTransformer(abc.ABC, t.Generic[_HOOK_RETURN_TYPE, _END_RESULT_TYPE]):
                 return self._handle_web_color(component)
             if type(component) is formatting_enum:
                 return self._handle_formatting(component)
+            if type(component) is InvalidFormatting:
+                return self._handle_invalid_formatting(component)
             if type(component) is TranslationTag:
                 return self._handle_translation_tag(component)
             if type(component) is str:
@@ -132,6 +135,9 @@ class _BaseTransformer(abc.ABC, t.Generic[_HOOK_RETURN_TYPE, _END_RESULT_TYPE]):
 
     @abc.abstractmethod
     def _handle_formatting(self, element: AnyFormatting, /) -> _HOOK_RETURN_TYPE: ...
+
+    @abc.abstractmethod
+    def _handle_invalid_formatting(self, element: InvalidFormatting, /) -> _HOOK_RETURN_TYPE: ...
 
     @abc.abstractmethod
     def _handle_minecraft_color(self, element: AnyMinecraftColor, /) -> _HOOK_RETURN_TYPE: ...
@@ -164,6 +170,10 @@ class _NothingTransformer(_BaseTransformer[str, str]):
         return ""
 
     @override
+    def _handle_invalid_formatting(self, _element: InvalidFormatting, /) -> str:
+        return ""
+
+    @override
     def _handle_translation_tag(self, _element: TranslationTag, /) -> str:
         return ""
 
@@ -189,6 +199,11 @@ class MinecraftTransformer(PlainTransformer):
 
     @override
     def _handle_formatting(self, element: AnyFormatting, /) -> str:
+        return "§" + element.value
+
+    # future compatibility
+    @override
+    def _handle_invalid_formatting(self, element: InvalidFormatting, /) -> str:
         return "§" + element.value
 
 

--- a/mcstatus/motd/components.py
+++ b/mcstatus/motd/components.py
@@ -23,7 +23,12 @@ __all__ = [
 # NOTE: keep in sync with the definition in docs (`docs/api/motd_parsing.rst`)
 # the autodocs plugin does not support type aliases yet, so those have to be
 # defined manually in docs
-ParsedMotdComponent: t.TypeAlias = "AnyFormatting | AnyMinecraftColor | WebColor | TranslationTag | str"
+ParsedMotdComponent: t.TypeAlias = "AnyFormatting | AnyMinecraftColor | InvalidFormatting | WebColor | TranslationTag | str"
+
+
+@dataclass(frozen=True)
+class InvalidFormatting:
+    value: str
 
 
 class JavaFormatting(Enum):

--- a/mcstatus/motd/components.py
+++ b/mcstatus/motd/components.py
@@ -12,6 +12,7 @@ __all__ = [
     "AnyMinecraftColor",
     "BedrockFormatting",
     "BedrockMinecraftColor",
+    "InvalidFormatting",
     "JavaFormatting",
     "JavaMinecraftColor",
     "ParsedMotdComponent",
@@ -28,6 +29,12 @@ ParsedMotdComponent: t.TypeAlias = "AnyFormatting | AnyMinecraftColor | InvalidF
 
 @dataclass(frozen=True)
 class InvalidFormatting:
+    """Unrecognized color formatting.
+
+    This might be because the color returned is genuinely invalid, or because
+    this is a new color which mcstatus doesn't yet recognize.
+    """
+
     value: str
 
 

--- a/tests/motd/conftest.py
+++ b/tests/motd/conftest.py
@@ -75,5 +75,6 @@ def source_bedrock() -> RawJavaResponseMotd:
         "§t27"
         "§u28"
         "§v29"
-        "§r30"
+        "§z30"
+        "§r31"
     )  # fmt: skip

--- a/tests/motd/test_motd_parse.py
+++ b/tests/motd/test_motd_parse.py
@@ -6,6 +6,7 @@ from mcstatus.motd import Motd
 from mcstatus.motd.components import (
     BedrockFormatting,
     BedrockMinecraftColor,
+    InvalidFormatting,
     JavaFormatting,
     JavaMinecraftColor,
     ParsedMotdComponent,
@@ -47,17 +48,22 @@ class TestMotdParse:
                 BedrockMinecraftColor.MATERIAL_LAPIS, "27",
                 BedrockMinecraftColor.MATERIAL_AMETHYST, "28",
                 BedrockMinecraftColor.MATERIAL_RESIN, "29",
-                BedrockFormatting.RESET, "30",
+                InvalidFormatting("z"), "30",
+                BedrockFormatting.RESET, "31",
             ],
             bedrock=True,
             raw=source_bedrock,
         )  # fmt: skip
 
-    @pytest.mark.parametrize(("bedrock", "expected"), [(True, BedrockMinecraftColor.MINECOIN_GOLD), (False, "&g")])
+    @pytest.mark.parametrize(
+        ("bedrock", "expected"), [(True, BedrockMinecraftColor.MINECOIN_GOLD), (False, InvalidFormatting("g"))]
+    )
     def test_parse_as_str_ignore_minecoin_gold_on_java(self, bedrock: bool, expected: ParsedMotdComponent):
         assert Motd.parse("&g", bedrock=bedrock).parsed == [expected]
 
-    @pytest.mark.parametrize(("bedrock", "expected"), [(True, BedrockMinecraftColor.MATERIAL_IRON), (False, "&i")])
+    @pytest.mark.parametrize(
+        ("bedrock", "expected"), [(True, BedrockMinecraftColor.MATERIAL_IRON), (False, InvalidFormatting("i"))]
+    )
     def test_parse_as_str_ignore_material_colors_on_java(self, bedrock: bool, expected: ParsedMotdComponent):
         assert Motd.parse("&i", bedrock=bedrock).parsed == [expected]
 
@@ -67,9 +73,8 @@ class TestMotdParse:
     def test_parse_as_str_underlined_on_java(self, bedrock: bool, expected: ParsedMotdComponent):
         assert Motd.parse("&n", bedrock=bedrock).parsed == [expected]
 
-    def test_parse_incorrect_color_passes(self):
-        """See `https://github.com/py-mine/mcstatus/pull/335#discussion_r985084188`_."""
-        assert Motd.parse("&z").parsed == ["&z"]
+    def test_parse_incorrect_formatting(self):
+        assert Motd.parse("&z").parsed == [InvalidFormatting("z")]
 
     def test_parse_uppercase_passes(self):
         assert Motd.parse("&A").parsed == [JavaMinecraftColor.GREEN]

--- a/tests/motd/test_transformers.py
+++ b/tests/motd/test_transformers.py
@@ -15,7 +15,7 @@ MotdParseFuncBedrockFlag: typing.TypeAlias = Callable[[RawJavaResponseMotd, bool
 
 
 def test_nothing_transformer():
-    assert _NothingTransformer(bedrock=False).transform(Motd.parse("&1a&bfoo&r").parsed) == ""
+    assert _NothingTransformer(bedrock=False).transform(Motd.parse("&1a&bfo&zo&r").parsed) == ""
 
 
 class TestMotdPlain:
@@ -43,7 +43,7 @@ class TestMotdMinecraft:
     def result() -> MotdParseFunc:
         return lambda text: Motd.parse(text).to_minecraft()
 
-    @pytest.mark.parametrize("motd", ["&1&2&3", "§123§5bc", "§1§2§3"])
+    @pytest.mark.parametrize("motd", ["&1&2&3&z", "§123§5bc&z", "§1§2§3§z"])
     @staticmethod
     def test_return_the_same(motd: str, result: MotdParseFunc):
         assert result(motd) == motd.replace("&", "§")
@@ -114,8 +114,8 @@ class TestMotdHTML:
             "<span style='color:rgb(44, 186, 168);text-shadow:0 0 1px rgb(11, 46, 42)'>26</span>"
             "<span style='color:rgb(33, 73, 123);text-shadow:0 0 1px rgb(8, 18, 30)'>27</span>"
             "<span style='color:rgb(154, 92, 198);text-shadow:0 0 1px rgb(38, 23, 49)'>28</span>"
-            "<span style='color:rgb(235, 114, 20);text-shadow:0 0 1px rgb(59, 29, 5)'>29</span>"
-            "30"
+            "<span style='color:rgb(235, 114, 20);text-shadow:0 0 1px rgb(59, 29, 5)'>2930</span>"
+            "31"
             "</p>"
         )
 
@@ -188,5 +188,5 @@ class TestMotdAnsi:
             "\033[0m\033[38;2;33;73;123m27"
             "\033[0m\033[38;2;154;92;198m28"
             "\033[0m\033[38;2;235;114;20m29"
-            "\033[0m30\033[0m"
+            "30\033[0m31\033[0m"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -351,7 +351,7 @@ requires-dist = [
     { name = "m2r2", specifier = "~=0.3.4" },
     { name = "packaging", specifier = "~=26.0" },
     { name = "sphinx", specifier = "~=9.1.0" },
-    { name = "sphinx-autodoc-typehints", specifier = "~=3.11.0" },
+    { name = "sphinx-autodoc-typehints", specifier = "~=3.12.0" },
     { name = "uv-dynamic-versioning", specifier = "~=0.14.0" },
 ]
 
@@ -992,14 +992,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.11.0"
+version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/ac/99f66f906b15718687525fdf3601ca0b50d19c5e88d57cd4275a89355926/sphinx_autodoc_typehints-3.11.0.tar.gz", hash = "sha256:0112b322e2ebd993c0561af3c9e4615481b42dec199d665d6bacc875f3371e96", size = 82518, upload-time = "2026-06-11T18:48:34.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/f2/d99787d34d881b2352c04ce02bcdf0a61adf54b389c86d438b7a8ac3ae20/sphinx_autodoc_typehints-3.12.0.tar.gz", hash = "sha256:6571eb33c72cdc616a9945730fcb43c5bcf3685e79f1e8aea144735e43d5230d", size = 83874, upload-time = "2026-06-25T15:44:47.786Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/55/7aaa2439e77cff66a6f348bb2d9894abf2b7b153595a5b974c5c277e9145/sphinx_autodoc_typehints-3.11.0-py3-none-any.whl", hash = "sha256:4ab73fe735c33168be3f34818034581155416e8e248d32ea1b604e90bea75223", size = 41610, upload-time = "2026-06-11T18:48:33.056Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/28/fa0f2ff73b8ca7987ebaa107d369c95459741ac73567e5079b4a881a981b/sphinx_autodoc_typehints-3.12.0-py3-none-any.whl", hash = "sha256:1a639b7cf71be13c4d8a4f0b552dcfcdf32ff39ac33ecb47398acb85863c2faf", size = 42548, upload-time = "2026-06-25T15:44:46.306Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I noticed this when working on https://github.com/py-mine/mcstatus/pull/1176: the latest Minecraft versions do not display invalid formattings. They just get ignored.