### PR TITLE
Support IPv6 DNS resolution

### DIFF
--- a/mcstatus/_net/dns.py
+++ b/mcstatus/_net/dns.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, cast
 
 import dns.asyncresolver
@@ -8,6 +9,7 @@ from dns.rdatatype import RdataType
 
 if TYPE_CHECKING:
     from dns.rdtypes.IN.A import A as ARecordAnswer
+    from dns.rdtypes.IN.AAAA import AAAA as AAAARecordAnswer  # ruff: ignore[constant-imported-as-non-constant]
     from dns.rdtypes.IN.SRV import SRV as SRVRecordAnswer  # ruff: ignore[constant-imported-as-non-constant]
 
 __all__ = [
@@ -21,20 +23,26 @@ __all__ = [
 
 
 def resolve_a_record(hostname: str, lifetime: float | None = None) -> str:
-    """Perform a DNS resolution for an A record to given hostname.
+    """Perform a DNS resolution for an A/AAAA record to given hostname.
 
     :param hostname: The address to resolve for.
-    :return: The resolved IP address from the A record
+    :return: The resolved IP address from the A/AAAA record
     :raises dns.exception.DNSException:
         One of the exceptions possibly raised by :func:`dns.resolver.resolve`.
         Most notably this will be :exc:`dns.exception.Timeout`, :exc:`dns.resolver.NXDOMAIN`
-        and :exc:`dns.resolver.NoAnswer`
+        and :exc:`dns.resolver.NoAnswer` The `NoAnswer` exception will only be raised if
+        neither A nor AAAA responses exist.
     """
-    answers = dns.resolver.resolve(hostname, RdataType.A, lifetime=lifetime, search=True)
-    # There should only be one answer here, though in case the server
+    # Prioritize IPv4, if available
+    try:
+        answer = dns.resolver.resolve(hostname, RdataType.A, lifetime=lifetime, search=True)
+    except dns.resolver.NoAnswer:
+        answer = dns.resolver.resolve(hostname, RdataType.AAAA, lifetime=lifetime, search=True)
+
+    # There should only be one record here, though in case the server
     # does actually point to multiple IPs, we just pick the first one
-    answer = cast("ARecordAnswer", answers[0])
-    ip = str(answer).rstrip(".")
+    record = cast("ARecordAnswer | AAAARecordAnswer", answer[0])
+    ip = str(record).rstrip(".")
     return ip
 
 
@@ -43,12 +51,38 @@ async def async_resolve_a_record(hostname: str, lifetime: float | None = None) -
 
     For more details, check it.
     """
-    answers = await dns.asyncresolver.resolve(hostname, RdataType.A, lifetime=lifetime, search=True)
-    # There should only be one answer here, though in case the server
-    # does actually point to multiple IPs, we just pick the first one
-    answer = cast("ARecordAnswer", answers[0])
-    ip = str(answer).rstrip(".")
-    return ip
+    # This will raise if any exceptions occur in either request, even if the
+    # other one succeeds, however, we will not raise no NoAnswer.
+    a_answer, aaaa_answer = await asyncio.gather(
+        dns.asyncresolver.resolve(
+            hostname,
+            RdataType.A,
+            lifetime=lifetime,
+            search=True,
+            raise_on_no_answer=False,
+        ),
+        dns.asyncresolver.resolve(
+            hostname,
+            RdataType.AAAA,
+            lifetime=lifetime,
+            search=True,
+            raise_on_no_answer=False,
+        ),
+    )
+
+    # prioritize IPv4 if available
+    for answer in (a_answer, aaaa_answer):
+        if answer.rrset is None:
+            continue  # NoAnswer
+
+        for record in answer:
+            record = cast("ARecordAnswer | AAAARecordAnswer", record)
+
+            ip = str(record).rstrip(".")
+            return ip
+
+    # TODO: Consider ExceptionGroup return once we support >=3.11
+    raise dns.resolver.NoAnswer(response=aaaa_answer.response)
 
 
 def resolve_srv_record(query_name: str, lifetime: float | None = None) -> tuple[str, int]:
@@ -61,12 +95,12 @@ def resolve_srv_record(query_name: str, lifetime: float | None = None) -> tuple[
         Most notably this will be :exc:`dns.exception.Timeout`, :exc:`dns.resolver.NXDOMAIN`
         and :exc:`dns.resolver.NoAnswer`
     """
-    answers = dns.resolver.resolve(query_name, RdataType.SRV, lifetime=lifetime, search=True)
-    # There should only be one answer here, though in case the server
+    answer = dns.resolver.resolve(query_name, RdataType.SRV, lifetime=lifetime, search=True)
+    # There should only be one record here, though in case the server
     # does actually point to multiple IPs, we just pick the first one
-    answer = cast("SRVRecordAnswer", answers[0])
-    host = str(answer.target).rstrip(".")
-    port = int(answer.port)
+    record = cast("SRVRecordAnswer", answer[0])
+    host = str(record.target).rstrip(".")
+    port = int(record.port)
     return host, port
 
 
@@ -75,12 +109,12 @@ async def async_resolve_srv_record(query_name: str, lifetime: float | None = Non
 
     For more details, check it.
     """
-    answers = await dns.asyncresolver.resolve(query_name, RdataType.SRV, lifetime=lifetime, search=True)
-    # There should only be one answer here, though in case the server
+    answer = await dns.asyncresolver.resolve(query_name, RdataType.SRV, lifetime=lifetime, search=True)
+    # There should only be one record here, though in case the server
     # does actually point to multiple IPs, we just pick the first one
-    answer = cast("SRVRecordAnswer", answers[0])
-    host = str(answer.target).rstrip(".")
-    port = int(answer.port)
+    record = cast("SRVRecordAnswer", answer[0])
+    host = str(record.target).rstrip(".")
+    port = int(record.port)
     return host, port
 
 

--- a/mcstatus/_net/dns.py
+++ b/mcstatus/_net/dns.py
@@ -51,38 +51,57 @@ async def async_resolve_a_record(hostname: str, lifetime: float | None = None) -
 
     For more details, check it.
     """
-    # This will raise if any exceptions occur in either request, even if the
-    # other one succeeds, however, we will not raise no NoAnswer.
-    a_answer, aaaa_answer = await asyncio.gather(
+    a_task = asyncio.create_task(
         dns.asyncresolver.resolve(
             hostname,
             RdataType.A,
             lifetime=lifetime,
             search=True,
             raise_on_no_answer=False,
-        ),
+        )
+    )
+    aaaa_task = asyncio.create_task(
         dns.asyncresolver.resolve(
             hostname,
             RdataType.AAAA,
             lifetime=lifetime,
             search=True,
             raise_on_no_answer=False,
-        ),
+        )
     )
 
     # prioritize IPv4 if available
-    for answer in (a_answer, aaaa_answer):
-        if answer.rrset is None:
-            continue  # NoAnswer
+    try:
+        a_answer = await a_task
+    except BaseException:
+        # Cancel the AAAA task if still running, then consume its result.
+        # Any exception from the unused lookup is intentionally discarded.
+        _ = aaaa_task.cancel()
+        _ = await asyncio.gather(aaaa_task, return_exceptions=True)
+        raise
 
-        for record in answer:
-            record = cast("ARecordAnswer | AAAARecordAnswer", record)
+    if a_answer.rrset is not None:
+        answer = a_answer
 
-            ip = str(record).rstrip(".")
-            return ip
+        # Cancel the AAAA task if still running, then consume its result.
+        # Any exception from the unused lookup is intentionally discarded.
+        _ = aaaa_task.cancel()
+        _ = await asyncio.gather(aaaa_task, return_exceptions=True)
+    else:
+        aaaa_answer = await aaaa_task
+        if aaaa_answer.rrset is None:
+            # TODO: Consider ExceptionGroup return once we support >=3.11
+            raise dns.resolver.NoAnswer(response=aaaa_answer.response)
 
-    # TODO: Consider ExceptionGroup return once we support >=3.11
-    raise dns.resolver.NoAnswer(response=aaaa_answer.response)
+        answer = aaaa_answer
+
+    for record in answer:
+        record = cast("ARecordAnswer | AAAARecordAnswer", record)
+
+        ip = str(record).rstrip(".")
+        return ip
+
+    raise RuntimeError(f"unreachable - DNS {answer=} was not a NoAnswer, but didn't have any records")
 
 
 def resolve_srv_record(query_name: str, lifetime: float | None = None) -> tuple[str, int]:

--- a/tests/net/test_address.py
+++ b/tests/net/test_address.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import ipaddress
 import sys
 from pathlib import Path
-from typing import Any, TYPE_CHECKING, cast, final
-from unittest.mock import MagicMock, Mock, patch
+from typing import Any, TYPE_CHECKING, final
+from unittest.mock import MagicMock, patch
 
 import dns.resolver
 import pytest
-from dns.rdatatype import RdataType
 
 from mcstatus._net.address import Address, async_minecraft_srv_address_lookup, minecraft_srv_address_lookup
 
@@ -20,61 +19,45 @@ if TYPE_CHECKING:
 class TestSRVLookup:
     @pytest.mark.parametrize("exception", [dns.resolver.NXDOMAIN, dns.resolver.NoAnswer])
     def test_address_no_srv(self, exception: DNSException):
-        with patch("dns.resolver.resolve") as resolve:
-            resolve.side_effect = [exception]
+        with patch("mcstatus._net.address.mc_dns.resolve_mc_srv", side_effect=exception):
             address = minecraft_srv_address_lookup("example.org", default_port=25565, lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
 
         assert address.host == "example.org"
         assert address.port == 25565
 
     @pytest.mark.parametrize("exception", [dns.resolver.NXDOMAIN, dns.resolver.NoAnswer])
     def test_address_no_srv_no_default_port(self, exception: DNSException):
-        with patch("dns.resolver.resolve") as resolve:
-            resolve.side_effect = [exception]
-            with pytest.raises(ValueError, match=r"^Given address 'example.org' doesn't contain port"):
-                _ = minecraft_srv_address_lookup("example.org", lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
+        with (
+            patch("mcstatus._net.address.mc_dns.resolve_mc_srv", side_effect=exception),
+            pytest.raises(ValueError, match=r"^Given address 'example.org' doesn't contain port"),
+        ):
+            _ = minecraft_srv_address_lookup("example.org", lifetime=3)
 
     def test_address_with_srv(self):
-        with patch("dns.resolver.resolve") as resolve:
-            answer = Mock()
-            answer.target = "different.example.org."
-            answer.port = 12345
-            resolve.return_value = [answer]
-
+        with patch("mcstatus._net.address.mc_dns.resolve_mc_srv", return_value=("different.example.org", 12345)):
             address = minecraft_srv_address_lookup("example.org", lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
         assert address.host == "different.example.org"
         assert address.port == 12345
 
     @pytest.mark.parametrize("exception", [dns.resolver.NXDOMAIN, dns.resolver.NoAnswer])
     async def test_async_address_no_srv(self, exception: DNSException):
-        with patch("dns.asyncresolver.resolve") as resolve:
-            resolve.side_effect = [exception]
+        with patch("mcstatus._net.address.mc_dns.async_resolve_mc_srv", side_effect=exception):
             address = await async_minecraft_srv_address_lookup("example.org", default_port=25565, lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
 
         assert address.host == "example.org"
         assert address.port == 25565
 
     @pytest.mark.parametrize("exception", [dns.resolver.NXDOMAIN, dns.resolver.NoAnswer])
     async def test_async_address_no_srv_no_default_port(self, exception: DNSException):
-        with patch("dns.asyncresolver.resolve") as resolve:
-            resolve.side_effect = [exception]
-            with pytest.raises(ValueError, match=r"^Given address 'example.org' doesn't contain port"):
-                _ = await async_minecraft_srv_address_lookup("example.org", lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
+        with (
+            patch("mcstatus._net.address.mc_dns.async_resolve_mc_srv", side_effect=exception),
+            pytest.raises(ValueError, match=r"^Given address 'example.org' doesn't contain port"),
+        ):
+            _ = await async_minecraft_srv_address_lookup("example.org", lifetime=3)
 
     async def test_async_address_with_srv(self):
-        with patch("dns.asyncresolver.resolve") as resolve:
-            answer = Mock()
-            answer.target = "different.example.org."
-            answer.port = 12345
-            resolve.return_value = [answer]
-
+        with patch("mcstatus._net.address.mc_dns.async_resolve_mc_srv", return_value=("different.example.org", 12345)):
             address = await async_minecraft_srv_address_lookup("example.org", lifetime=3)
-            resolve.assert_called_once_with("_minecraft._tcp.example.org", RdataType.SRV, lifetime=3, search=True)
         assert address.host == "different.example.org"
         assert address.port == 12345
 
@@ -184,26 +167,16 @@ class TestAddressIPResolving:
         self.ipv6_addr = Address("::1", 25565)
 
     def test_ip_resolver_with_hostname(self):
-        with patch("dns.resolver.resolve") as resolve:
-            answer = MagicMock()
-            cast("MagicMock", answer.__str__).return_value = "48.225.1.104."
-            resolve.return_value = [answer]
-
+        with patch("mcstatus._net.address.mc_dns.resolve_a_record", return_value="48.225.1.104"):
             resolved_ip = self.host_addr.resolve_ip(lifetime=3)
 
-            resolve.assert_called_once_with(self.host_addr.host, RdataType.A, lifetime=3, search=True)
             assert isinstance(resolved_ip, ipaddress.IPv4Address)
             assert str(resolved_ip) == "48.225.1.104"
 
     async def test_async_ip_resolver_with_hostname(self):
-        with patch("dns.asyncresolver.resolve") as resolve:
-            answer = MagicMock()
-            cast("MagicMock", answer.__str__).return_value = "48.225.1.104."
-            resolve.return_value = [answer]
-
+        with patch("mcstatus._net.address.mc_dns.async_resolve_a_record", return_value="48.225.1.104"):
             resolved_ip = await self.host_addr.async_resolve_ip(lifetime=3)
 
-            resolve.assert_called_once_with(self.host_addr.host, RdataType.A, lifetime=3, search=True)
             assert isinstance(resolved_ip, ipaddress.IPv4Address)
             assert str(resolved_ip) == "48.225.1.104"
 

--- a/tests/net/test_dns.py
+++ b/tests/net/test_dns.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+from unittest.mock import patch
+
+import dns.exception
+import dns.message
+import dns.name
+import dns.rdata
+import dns.rdataclass
+import dns.resolver
+import pytest
+from dns.rdatatype import RdataType
+
+from mcstatus._net.dns import async_resolve_a_record, resolve_a_record
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+
+def dns_answer(record_type: RdataType, ip: str | None) -> dns.resolver.Answer:
+    qname = dns.name.from_text("example.org.")
+    response = cast("dns.message.QueryMessage", dns.message.make_response(dns.message.make_query(qname, record_type)))
+    if ip is not None:
+        answer = response.find_rrset(dns.message.ANSWER, qname, dns.rdataclass.IN, record_type, create=True)
+        answer.add(dns.rdata.from_text(dns.rdataclass.IN, record_type, ip), ttl=60)
+
+    return dns.resolver.Answer(qname, record_type, dns.rdataclass.IN, response)
+
+
+def dns_mock(
+    answers: Mapping[RdataType, dns.resolver.Answer],
+) -> Callable[..., dns.resolver.Answer]:
+    def resolve(
+        qname: dns.name.Name | str,
+        rdtype: RdataType | str = RdataType.A,
+        rdclass: dns.rdataclass.RdataClass | str = dns.rdataclass.IN,
+        tcp: bool = False,  # ruff: ignore[boolean-default-value-positional-argument]
+        source: str | None = None,
+        raise_on_no_answer: bool = True,  # ruff: ignore[boolean-default-value-positional-argument]
+        source_port: int = 0,
+        lifetime: float | None = None,
+        search: bool | None = None,
+        backend: object | None = None,
+    ) -> dns.resolver.Answer:
+        answer = answers[RdataType.make(rdtype)]
+        if answer.rrset is None and raise_on_no_answer:
+            raise dns.resolver.NoAnswer(response=answer.response)
+        return answer
+
+    return resolve
+
+
+class TestARecordResolution:
+    def test_prefers_ipv4_record(self):
+        answers = {
+            RdataType.A: dns_answer(RdataType.A, "192.0.2.1"),
+            RdataType.AAAA: dns_answer(RdataType.AAAA, "2001:db8::1"),
+        }
+        with patch("dns.resolver.resolve", side_effect=dns_mock(answers)):
+            assert resolve_a_record("example.org", lifetime=3) == "192.0.2.1"
+
+    def test_falls_back_to_ipv6_record(self):
+        with patch(
+            "dns.resolver.resolve",
+            side_effect=dns_mock(
+                {
+                    RdataType.A: dns_answer(RdataType.A, None),
+                    RdataType.AAAA: dns_answer(RdataType.AAAA, "2001:db8::1"),
+                }
+            ),
+        ):
+            assert resolve_a_record("example.org", lifetime=3) == "2001:db8::1"
+
+    @pytest.mark.parametrize("exception", [dns.exception.Timeout, dns.resolver.NXDOMAIN])
+    def test_propagates_resolution_failure(self, exception: type[dns.exception.DNSException]):
+        with (
+            patch("dns.resolver.resolve", side_effect=exception),
+            pytest.raises(exception),
+        ):
+            _ = resolve_a_record("example.org")
+
+    async def test_async_prefers_ipv4_record(self):
+        answers = {
+            RdataType.A: dns_answer(RdataType.A, "192.0.2.1"),
+            RdataType.AAAA: dns_answer(RdataType.AAAA, "2001:db8::1"),
+        }
+
+        with patch(
+            "dns.asyncresolver.resolve",
+            side_effect=dns_mock(answers),
+        ):
+            assert await async_resolve_a_record("example.org", lifetime=3) == "192.0.2.1"
+
+    async def test_async_falls_back_to_ipv6_record(self):
+        with patch(
+            "dns.asyncresolver.resolve",
+            side_effect=dns_mock(
+                {
+                    RdataType.A: dns_answer(RdataType.A, None),
+                    RdataType.AAAA: dns_answer(RdataType.AAAA, "2001:db8::1"),
+                }
+            ),
+        ):
+            assert await async_resolve_a_record("example.org") == "2001:db8::1"
+
+    @pytest.mark.parametrize("exception", [dns.exception.Timeout, dns.resolver.NXDOMAIN])
+    async def test_async_propagates_resolution_failure(self, exception: type[dns.exception.DNSException]):
+        with (
+            patch("dns.asyncresolver.resolve", side_effect=exception),
+            pytest.raises(exception),
+        ):
+            _ = await async_resolve_a_record("example.org")
+
+    async def test_async_raises_no_answer_when_no_records_exist(self):
+        with (
+            patch(
+                "dns.asyncresolver.resolve",
+                side_effect=dns_mock(
+                    {
+                        RdataType.A: dns_answer(RdataType.A, None),
+                        RdataType.AAAA: dns_answer(RdataType.AAAA, None),
+                    }
+                ),
+            ),
+            pytest.raises(dns.resolver.NoAnswer),
+        ):
+            _ = await async_resolve_a_record("example.org")


### PR DESCRIPTION
Closes #1195

IP resolution now handles IPv6 AAAA records too, they are however handled as secondary to IPv4 records:

<img width="605" height="285" alt="Image" src="https://github.com/user-attachments/assets/456e06ca-3f87-4a33-9660-2ad2b065f2a3" />

I will say though that I wasn't able to further test IPv6 working down the line, as I don't currently have IPv6 connectivity on my machine, so `s.query()` fails for me with `OSError: [Errno 101] Network is unreachable`. It would probably be a good idea to validate the whole flow before merging.